### PR TITLE
Add metadata to package.json

### DIFF
--- a/UI/package.json
+++ b/UI/package.json
@@ -1,6 +1,11 @@
 {
   "name": "devops-dashboard",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/capitalone/Hygieia"
+  },
+  "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
     "bower": "^1.4.1",


### PR DESCRIPTION
to eliminate npm warnings.

```
$ npm install
npm WARN package.json devops-dashboard@0.0.0 No repository field.
npm WARN package.json devops-dashboard@0.0.0 No license field.
```