### PR TITLE
Add missing semicolons

### DIFF
--- a/Setup.md
+++ b/Setup.md
@@ -8,7 +8,7 @@ The following components are required to run Hygieia:
 * Mongo DB 2.6+
      * [Download & Installation instructions](https://www.mongodb.org/downloads#previous)
      * Configure Mongodb
-      * Name the database as dashboarddb.
+      * Name the database as dashboarddb. (Note: This is the same database that the collectors write to. So make sure that this name matches with the database names in collector properties)
       * create a user called dashboarduser with read/write priveleges.
       * Turn Authentication on.
 

--- a/UI/src/components/widgets/codeanalysis/view.js
+++ b/UI/src/components/widgets/codeanalysis/view.js
@@ -77,7 +77,7 @@
             var testResult = _.isEmpty(response.result) ? { testSuites: []} : response.result[0];
             var allZeros = {
                 failureCount: 0, errorCount: 0, skippedCount: 0, totalCount: 0
-            }
+            };
 
             // Aggregate the counts of all Functional test suites
             var aggregate = _.reduce(_.filter(testResult.testSuites, { type: "Functional" }), function(result, suite) {
@@ -85,7 +85,7 @@
                 result.errorCount += suite.errorCount;
                 result.skippedCount += suite.skippedCount;
                 result.totalCount += suite.totalCount;
-                return result
+                return result;
             }, allZeros);
             var passed = aggregate.totalCount - aggregate.failureCount - aggregate.errorCount - aggregate.skippedCount;
             var allPassed = aggregate.errorCount === 0 && aggregate.failureCount === 0;


### PR DESCRIPTION
to prevent warnings when running `gulp serve`:

    /Users/marca/dev/git-repos/Hygieia/UI/src/components/widgets/codeanalysis/view.js
      line 80  col 14  Missing semicolon.
      line 88  col 30  Missing semicolon.

      ⚠  2 warnings