### PR TITLE
github-collector: Log to github-collector log file

### DIFF
--- a/GitHubSourceCodeCollector/src/main/resources/logback.xml
+++ b/GitHubSourceCodeCollector/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
  <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- rollover daily -->
-      <fileNamePattern>buildcollector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>github-collector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <timeBasedFileNamingAndTriggeringPolicy
             class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
         <!-- or whenever the file size reaches 100MB -->

--- a/Setup.md
+++ b/Setup.md
@@ -8,7 +8,7 @@ The following components are required to run Hygieia:
 * Mongo DB 2.6+
      * [Download & Installation instructions](https://www.mongodb.org/downloads#previous)
      * Configure Mongodb
-      * Name the database as dashboarddb.
+      * Name the database as dashboarddb. (Note: This is the same database that the collectors write to. So make sure that this name matches with the database names in collector properties)
       * create a user called dashboarduser with read/write priveleges.
       * Turn Authentication on.
 


### PR DESCRIPTION
instead of buildcollector log file. The buildcollector log file had the
output of both the Jenkins collector and the GitHub collector
intermixed like this:

```
monkey@hygieia:/opt/hygieia/collectors$ tail -f buildcollector-2015-08-14.0.log
2015-08-14 00:21:00,002 INFO  c.c.d.collector.GitHubCollectorTask - ------------------------------
2015-08-14 00:21:00,002 INFO  c.c.d.collector.GitHubCollectorTask - Starting...
2015-08-14 00:21:00,002 INFO  c.c.d.collector.GitHubCollectorTask - ------------------------------
2015-08-14 00:21:00,080 INFO  c.c.d.collector.HudsonCollectorTask - Fetched jobs                0s
2015-08-14 00:21:00,129 INFO  c.c.d.collector.HudsonCollectorTask - New jobs           0        0s
2015-08-14 00:21:00,290 INFO  c.c.d.collector.HudsonCollectorTask - New builds         0        0s
2015-08-14 00:21:00,290 INFO  c.c.d.collector.HudsonCollectorTask - Finished                    0s
2015-08-14 00:21:00,545 INFO  c.c.d.collector.GitHubCollectorTask - Repo Count         5        0s
2015-08-14 00:21:00,546 INFO  c.c.d.collector.GitHubCollectorTask - New Commits        0        0s
2015-08-14 00:21:00,546 INFO  c.c.d.collector.GitHubCollectorTask - Finished                    0s
```

Cc: @sudarkoff, @aconrad