### PR TITLE
Added capabilities to run api in an embedded Jetty container

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -24,3 +24,19 @@ For the API web application to use this property file, make sure that the follow
 ```bash
 DASHBOARD_PROP=[path to dashboard.properties file]
 ```
+
+
+# Run the API
+ ### 1. Embedded Jetty container
+
+```bash
+mvn jetty:run   -DPROP_FILE=<Path to dashboard.properties file>
+```
+
+  ### 2. Tomcat container
+   * Copy the genrated war file  from project target folder after you have build the project into tomcat webapps folder
+   * Add a file setEnv.sh into Tomcat bin folder with following content
+   ```bash
+   export DASHBOARD_PROP=<Path to dashboard.properties file>
+   ```
+   * Start the tomcat container.

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -72,7 +72,26 @@
     </execution>
   </executions>
 </plugin>
-		</plugins>
+
+
+<plugin>
+  <groupId>org.eclipse.jetty</groupId>
+  <artifactId>jetty-maven-plugin</artifactId>
+  <version>9.3.2.v20150730</version>
+	<configuration>
+    <systemProperties>
+      <systemProperty>
+         <name>dashboard.prop</name>
+         <value>${PROP_FILE}</value>
+       </systemProperty>
+    </systemProperties>
+    <webApp>
+      <contextPath>/api</contextPath>
+    </webApp>
+   </configuration>
+</plugin>
+
+	</plugins>
 	</build>
 
 	<dependencies>


### PR DESCRIPTION
the api layer can now be run in an embedded Jetty container by running the command
```bash
mvn jetty:run   -DPROP_FILE=<Path to dashboard.properties file>
```