### PR TITLE
Docker containers for Hygieia and UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,19 @@ gradle.properties
 common/src/querydsl
 common/src/generated
 *.log
+# Eclipse Core
+.project
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# CDT-specific
+.cproject
+
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+.settings/

--- a/UI/README.md
+++ b/UI/README.md
@@ -60,3 +60,32 @@ or you can run via maven from UI project root folder
  for local testing of Hygieia UI layer
 
 All data is currently coming from the test-data folder so you shouldn't need an api, but also means no settings will be saved..
+
+By default this expects the api project to run from the same server.
+The best way to accomplish this is by using a proxy pass in nginx or apache to take all /api requests and pass them back to the API server.
+
+### To Docker-ize
+```bash
+mvn clean package docker:build
+```
+
+Expectation is you have already dockerized the API and have a mongo configured
+```bash
+cd Hygieia/api
+mvn clean package docker:build
+
+cd ../UI
+mvn clean package docker:build
+
+docker run -h mongo -d --name mongo mongo:latest
+docker run -h hygieia_api --link mongo:mongo -P -d --name hygieia_api hygieia_api
+docker run -d -P -h hygieia_ui --name hygieia_ui --link hygieia_api:api hygieia_ui
+
+# to find the port that hygieia_ui is now running on
+docker port hygieia_ui 80
+
+```
+
+Using the ip address of your docker instance either boot2docker ip or docker-machine env <default> and the above port
+you should be able to get to the front UI page and create an account.
+

--- a/UI/docker/Dockerfile
+++ b/UI/docker/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx
+COPY /usr/share/nginx/html /usr/share/nginx/html
+COPY /etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
+

--- a/UI/docker/default.conf
+++ b/UI/docker/default.conf
@@ -1,0 +1,45 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/log/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    location /api {
+        proxy_pass   http://hygieia_api:8080/api;
+    }
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}
+

--- a/UI/pom.xml
+++ b/UI/pom.xml
@@ -73,6 +73,32 @@
 	 </executions>
 
 </plugin>
+
+<plugin>
+      <groupId>com.spotify</groupId>
+      <artifactId>docker-maven-plugin</artifactId>
+      <version>0.3.2</version>
+      <configuration>
+        <imageName>hygieia_ui</imageName>
+        <baseImage>nginx</baseImage>
+        <!--  <entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>-->
+        <!-- copy the service's jar file from target into the root directory of the image -->
+        <dockerDirectory>docker</dockerDirectory> 
+        <resources>
+           <resource>
+             <targetPath>/usr/share/nginx/html</targetPath>
+             <directory>dist</directory>
+             <include>*/**</include>
+           </resource>
+           <resource>
+             <targetPath>/etc/nginx/conf.d</targetPath>
+             <directory>docker</directory>
+             <include>default.conf</include>
+           </resource>
+        </resources>
+      </configuration>
+    </plugin>
+    
 </plugins>
 </build>
 </project>

--- a/UI/src/app/index.less
+++ b/UI/src/app/index.less
@@ -3,7 +3,7 @@
 @import '../components/widgets/codeanalysis/view.less';
 @import '../components/widgets/deploy/view.less';
 @import '../components/widgets/feature/style.less';
-@import '../components/widgets/pipeline/pipeline.less';
 @import '../components/widgets/monitor/monitor.less';
+@import '../components/widgets/pipeline/pipeline.less';
 @import '../components/widgets/repo/repo.less';
 // endinjector

--- a/UI/src/index.html
+++ b/UI/src/index.html
@@ -37,8 +37,8 @@
 <!-- build:js({.tmp,src}) scripts/app.js -->
 <!-- inject:js -->
 <script src="app/app.js"></script>
-<script src="components/widgets/codeanalysis/directives/guage-container.js"></script>
 <script src="components/widgets/build/directives/directives.js"></script>
+<script src="components/widgets/codeanalysis/directives/guage-container.js"></script>
 <script src="app/dashboard/core/module.js"></script>
 <script src="app/dashboard/core/providers/widget-manager.js"></script>
 <script src="app/dashboard/core/extensions/ng-fitText.js"></script>
@@ -71,13 +71,13 @@
 <script src="components/widgets/deploy/module.js"></script>
 <script src="components/widgets/deploy/detail.js"></script>
 <script src="components/widgets/deploy/config.js"></script>
-<script src="components/widgets/codeanalysis/view.js"></script>
-<script src="components/widgets/codeanalysis/module.js"></script>
-<script src="components/widgets/codeanalysis/config.js"></script>
 <script src="components/widgets/build/view.js"></script>
 <script src="components/widgets/build/module.js"></script>
 <script src="components/widgets/build/detail.js"></script>
 <script src="components/widgets/build/config.js"></script>
+<script src="components/widgets/codeanalysis/view.js"></script>
+<script src="components/widgets/codeanalysis/module.js"></script>
+<script src="components/widgets/codeanalysis/config.js"></script>
 <script src="app/dashboard/filters/from-now.js"></script>
 <script src="app/dashboard/filters/duration.js"></script>
 <script src="app/dashboard/directives/widget.js"></script>

--- a/api/README.md
+++ b/api/README.md
@@ -40,3 +40,23 @@ mvn jetty:run   -DPROP_FILE=<Path to dashboard.properties file>
    export DASHBOARD_PROP=<Path to dashboard.properties file>
    ```
    * Start the tomcat container.
+
+
+# To Docker-ize
+Utilize sample config dashboard.properties in docker/dashboard.properties
+It assumes there's a host called mongo, you can use docker to link them however ensure you use a volumn mounted mongo instance if productionizing.
+
+```bash
+mvn clean package docker:build
+mvn docker:removeImage -DimageName=hygieia_api
+
+docker run -h mongo -d --name mongo mongo:latest
+docker run -h hygieia_api --link mongo:mongo -P -d --name hygieia_api hygieia_api
+```
+
+View port by running
+```bash
+docker ps
+```
+Take the port mapping and the IP for your docker-machine <env> ip and verify by http://<docker-machine env ip>:<docker port for hygieia_api>/api/dashboard
+

--- a/api/docker/Dockerfile
+++ b/api/docker/Dockerfile
@@ -1,0 +1,4 @@
+FROM tomcat
+ADD /usr/local/tomcat/webapps/api.war /usr/local/tomcat/webapps/api.war
+ADD /dashboard.properties /dashboard.properties
+ENV DASHBOARD_PROP /dashboard.properties 

--- a/api/docker/dashboard.properties
+++ b/api/docker/dashboard.properties
@@ -1,0 +1,6 @@
+#dashboard.properties
+dbname=dashboarddb
+#dbusername=mongo
+#dbpassword=[MongoDb Database Password]
+dbhost=mongo
+dbport=27017

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -28,6 +28,7 @@
 			<url></url>
 		</snapshotRepository>
 	</distributionManagement>
+	
 	<build>
 		<finalName>api</finalName>
 		<plugins>
@@ -90,8 +91,64 @@
     </webApp>
    </configuration>
 </plugin>
-
+<plugin>
+      <groupId>com.spotify</groupId>
+      <artifactId>docker-maven-plugin</artifactId>
+      <version>0.3.2</version>
+      <configuration>
+        <imageName>hygieia_api</imageName>
+        <baseImage>tomcat</baseImage>
+        <!--  <entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>-->
+        <!-- copy the service's jar file from target into the root directory of the image -->
+        <dockerDirectory>docker</dockerDirectory> 
+        <resources>
+           <resource>
+             <targetPath>/usr/local/tomcat/webapps</targetPath>
+             <directory>${project.build.directory}</directory>
+             <include>${project.build.finalName}.war</include>
+           </resource>
+           <resource>
+             <targetPath>/</targetPath>
+             <directory>docker</directory>
+             <include>dashboard.properties</include>
+           </resource>
+        </resources>
+      </configuration>
+    </plugin>
 	</plugins>
+		<pluginManagement>
+			<plugins>
+				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+				<plugin>
+					<groupId>org.eclipse.m2e</groupId>
+					<artifactId>lifecycle-mapping</artifactId>
+					<version>1.0.0</version>
+					<configuration>
+						<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>org.jacoco</groupId>
+										<artifactId>
+											jacoco-maven-plugin
+										</artifactId>
+										<versionRange>
+											[0.5.8.201207111220,)
+										</versionRange>
+										<goals>
+											<goal>prepare-agent</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore></ignore>
+									</action>
+								</pluginExecution>
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,30 @@
     <build>
         <pluginManagement>
             <plugins>
+             <plugin>
+            <groupId>org.eclipse.m2e</groupId>
+            <artifactId>lifecycle-mapping</artifactId>
+            <version>1.0.0</version>
+            <configuration>
+                <lifecycleMappingMetadata>
+                    <pluginExecutions>
+                        <pluginExecution>
+                            <pluginExecutionFilter>
+                                <groupId>org.jacoco</groupId>
+                                <artifactId>jacoco-maven-plugin</artifactId>
+                                <versionRange>[0.0.1,)</versionRange>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </pluginExecutionFilter>
+                            <action>
+                                <ignore />
+                            </action>
+                        </pluginExecution>
+                    </pluginExecutions>
+                </lifecycleMappingMetadata>
+            </configuration>
+        </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
@@ -37,5 +61,12 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+        	<plugin>
+        		<groupId>com.spotify</groupId>
+        		<artifactId>docker-maven-plugin</artifactId>
+        		<version>0.3.2</version>
+        	</plugin>
+        </plugins>
     </build>
 </project>


### PR DESCRIPTION
Ability to run separate Docker containers for the API and the UI, similar to production layouts.

The API is using a tomcat container and the UI is using an nginx container
The docker images are part of the maven compile using spotify's docker plugin

```bash
cd api
mvn clean package docker:build

cd ../UI
mvn clean package docker:build
```
This will create 2 containers for you, hygieia_api and hygieia_ui
You can now create a swarm, connect a docker or managed mongo, to run it all within a standard docker-machine

```bash
docker run -h mongo -d --name mongo mongo:latest
docker run -h hygieia_api --link mongo:mongo -P -d --name hygieia_api hygieia_api
docker run -d -P -h hygieia_ui --name hygieia_ui --link hygieia_api:api hygieia_ui
```
hygieia_api expects a network link / alias called mongo
hygieia_ui expects a network link / alias called hygieia_api 

