### PR TITLE
Modified Project Pom's for Maven Central release

### DIFF
--- a/BuildCollector/pom.xml
+++ b/BuildCollector/pom.xml
@@ -5,48 +5,34 @@
 	<artifactId>hudson-collector</artifactId>
 	<packaging>jar</packaging>
 	<version>0.1.1</version>
-	<name>Hudson Collector</name>
+	<name>${project.groupId}:${project.artifactId}</name>
+	<description>BuildCollector Microservice</description>
+	<url>https://github.com/capitalone/Hygieia</url>
 
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.2.1.RELEASE</version>
+		<groupId>com.capitalone.dashboard</groupId>
+		<artifactId>Hygieia</artifactId>
+		<version>1.0</version>
 	</parent>
 
-	<scm>
-		<connection></connection>
-		<developerConnection></developerConnection>
-		<url></url>
-		<tag></tag>
-	</scm>
+
 	<distributionManagement>
-		<repository>
-			<id>nexus</id>
-			<url></url>
-		</repository>
-		<snapshotRepository>
-			<id>nexus</id>
-			<url></url>
-		</snapshotRepository>
-	</distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
 	<!-- Package as an executable jar -->
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.3</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>nexus</serverId>
-					<nexusUrl></nexusUrl>
-					<stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-					<stagingProgressPauseDurationSeconds>15</stagingProgressPauseDurationSeconds>
-				</configuration>
 			</plugin>
 		</plugins>
 

--- a/CodeQualityCollector/pom.xml
+++ b/CodeQualityCollector/pom.xml
@@ -5,30 +5,27 @@
     <artifactId>sonar-collector</artifactId>
     <packaging>jar</packaging>
     <version>0.1.0</version>
-    <name>Sonar Collector</name>
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>CodeQuality Collector Microservices currently collects data from Sonar</description>
+    <url>https://github.com/capitalone/Hygieia</url>
+
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.2.1.RELEASE</version>
-    </parent>
+  		<groupId>com.capitalone.dashboard</groupId>
+  		<artifactId>Hygieia</artifactId>
+  		<version>1.0</version>
+  	</parent>
 
-	<scm>
-		<connection></connection>
-		<developerConnection></developerConnection>
-		<url></url>
-		<tag></tag>
-	</scm>
-		<distributionManagement>
-		<repository>
-			<id>nexus</id>
-			<url></url>
-		</repository>
-		<snapshotRepository>
-			<id>nexus</id>
-			<url></url>
-		</snapshotRepository>
-	</distributionManagement>
+    <distributionManagement>
+      <snapshotRepository>
+        <id>ossrh</id>
+        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      </snapshotRepository>
+      <repository>
+        <id>ossrh</id>
+        <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      </repository>
+    </distributionManagement>
 
     <!-- Package as an executable jar -->
     <build>
@@ -48,6 +45,9 @@
     <properties>
         <java.version>1.7</java.version>
     </properties>
+
+
+
 
     <dependencies>
         <!-- Project Deps-->

--- a/DeployCollector/pom.xml
+++ b/DeployCollector/pom.xml
@@ -5,48 +5,34 @@
 	<artifactId>udeploy-collector</artifactId>
 	<packaging>jar</packaging>
 	<version>0.1.1</version>
-	<name>UDeploy Collector</name>
+	<name>${project.groupId}:${project.artifactId}</name>
+	<description>Deploy Collector microservice currently collects data from IBM UCD</description>
+	<url>https://github.com/capitalone/Hygieia</url>
+
 
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.2.1.RELEASE</version>
+		<groupId>com.capitalone.dashboard</groupId>
+		<artifactId>Hygieia</artifactId>
+		<version>1.0</version>
 	</parent>
 
-	<scm>
-		<connection></connection>
-		<developerConnection></developerConnection>
-		<url></url>
-		<tag>HEAD</tag>
-	</scm>
 	<distributionManagement>
-		<repository>
-			<id>nexus</id>
-			<url></url>
-		</repository>
 		<snapshotRepository>
-			<id>nexus</id>
-			<url></url>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 		</snapshotRepository>
+		<repository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+		</repository>
 	</distributionManagement>
+
 	<!-- Package as an executable jar -->
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.3</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>nexus</serverId>
-					<nexusUrl></nexusUrl>
-					<stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-					<stagingProgressPauseDurationSeconds>15</stagingProgressPauseDurationSeconds>
-				</configuration>
 			</plugin>
 		</plugins>
 

--- a/GitHubSourceCodeCollector/pom.xml
+++ b/GitHubSourceCodeCollector/pom.xml
@@ -5,48 +5,34 @@
 	<artifactId>github-collector</artifactId>
 	<packaging>jar</packaging>
 	<version>1.0.0</version>
-	<name>GitHub Collector</name>
+	<name>${project.groupId}:${project.artifactId}</name>
+	<description>Github Collector Microservice collecting stats from Github</description>
+	<url>https://github.com/capitalone/Hygieia</url>
+
 
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.2.1.RELEASE</version>
+		<groupId>com.capitalone.dashboard</groupId>
+		<artifactId>Hygieia</artifactId>
+		<version>1.0</version>
 	</parent>
 
-	<scm>
-		<connection></connection>
-		<developerConnection></developerConnection>
-		<url></url>
-		<tag>HEAD</tag>
-	</scm>
 	<distributionManagement>
-		<repository>
-			<id>nexus</id>
-			<url></url>
-		</repository>
-		<snapshotRepository>
-			<id>nexus</id>
-			<url></url>
-		</snapshotRepository>
-	</distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
 	<!-- Package as an executable jar -->
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.3</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>nexus</serverId>
-					<nexusUrl></nexusUrl>
-					<stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-					<stagingProgressPauseDurationSeconds>15</stagingProgressPauseDurationSeconds>
-				</configuration>
 			</plugin>
 		</plugins>
 
@@ -60,6 +46,7 @@
 	<properties>
 		<java.version>1.7</java.version>
 	</properties>
+
 
 	<dependencies>
 		<!-- Project Deps -->

--- a/JenkinsCucumberTestCollector/pom.xml
+++ b/JenkinsCucumberTestCollector/pom.xml
@@ -5,48 +5,33 @@
 	<artifactId>jenkins-cucumber-test-collector</artifactId>
 	<packaging>jar</packaging>
 	<version>1.0.0.1</version>
-	<name>Cucumber Test Collector from Hudson/Jenkins</name>
+	<name>${project.groupId}:${project.artifactId}</name>
+	<description>Jenkins Cucumber Collector</description>
+	<url>https://github.com/capitalone/Hygieia</url>
 
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.2.1.RELEASE</version>
+		<groupId>com.capitalone.dashboard</groupId>
+		<artifactId>Hygieia</artifactId>
+		<version>1.0</version>
 	</parent>
 
-	<scm>
-		<connection></connection>
-		<developerConnection></developerConnection>
-		<url></url>
-		<tag>HEAD</tag>
-	</scm>
 	<distributionManagement>
-		<repository>
-			<id>nexus</id>
-			<url></url>
-		</repository>
 		<snapshotRepository>
-			<id>nexus</id>
-			<url></url>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 		</snapshotRepository>
+		<repository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+		</repository>
 	</distributionManagement>
+
 	<!-- Package as an executable jar -->
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.3</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>nexus</serverId>
-					<nexusUrl></nexusUrl>
-					<stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-					<stagingProgressPauseDurationSeconds>15</stagingProgressPauseDurationSeconds>
-				</configuration>
 			</plugin>
 		</plugins>
 

--- a/JiraFeatureCollector/pom.xml
+++ b/JiraFeatureCollector/pom.xml
@@ -6,7 +6,9 @@
 	<artifactId>jira-feature-collector</artifactId>
 	<packaging>jar</packaging>
 	<version>1.0.1</version>
-	<name>jira-feature-collector</name>
+	<name>${project.groupId}:${project.artifactId}</name>
+	<description>Jira collector micorservice collects data from Jira</description>
+	<url>https://github.com/capitalone/Hygieia</url>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -16,28 +18,22 @@
 	</properties>
 
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.2.1.RELEASE</version>
+		<groupId>com.capitalone.dashboard</groupId>
+		<artifactId>Hygieia</artifactId>
+		<version>1.0</version>
 	</parent>
 
-	<scm>
-		<connection></connection>
-		<developerConnection></developerConnection>
-		<url></url>
-		<tag>HEAD</tag>
-	</scm>
-
 	<distributionManagement>
-		<repository>
-			<id>nexus</id>
-			<url></url>
-		</repository>
 		<snapshotRepository>
-			<id>nexus</id>
-			<url></url>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 		</snapshotRepository>
+		<repository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+		</repository>
 	</distributionManagement>
+
 
 	<!-- Package as an executable jar -->
 	<build>
@@ -46,18 +42,6 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.3</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>nexus</serverId>
-					<nexusUrl></nexusUrl>
-					<stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-					<stagingProgressPauseDurationSeconds>15</stagingProgressPauseDurationSeconds>
-				</configuration>
 			</plugin>
 		</plugins>
 

--- a/SourceCodeCollector/pom.xml
+++ b/SourceCodeCollector/pom.xml
@@ -5,48 +5,33 @@
 	<artifactId>subversion-collector</artifactId>
 	<packaging>jar</packaging>
 	<version>0.1.0</version>
-	<name>Subversion Collector</name>
+	<name>${project.groupId}:${project.artifactId}</name>
+	<description>Subversion collector micorservice</description>
+	<url>https://github.com/capitalone/Hygieia</url>
 
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.2.1.RELEASE</version>
+		<groupId>com.capitalone.dashboard</groupId>
+		<artifactId>Hygieia</artifactId>
+		<version>1.0</version>
 	</parent>
 
-	<scm>
-		<connection></connection>
-		<developerConnection></developerConnection>
-		<url></url>
-		<tag>HEAD</tag>
-	</scm>
 	<distributionManagement>
-		<repository>
-			<id>nexus</id>
-			<url></url>
-		</repository>
 		<snapshotRepository>
-			<id>nexus</id>
-			<url></url>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 		</snapshotRepository>
+		<repository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+		</repository>
 	</distributionManagement>
+
 	<!-- Package as an executable jar -->
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.3</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>nexus</serverId>
-					<nexusUrl></nexusUrl>
-					<stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-					<stagingProgressPauseDurationSeconds>15</stagingProgressPauseDurationSeconds>
-				</configuration>
 			</plugin>
 		</plugins>
 
@@ -60,6 +45,7 @@
 	<properties>
 		<java.version>1.7</java.version>
 	</properties>
+
 
 	<dependencies>
 		<!-- Project Deps -->

--- a/UI/pom.xml
+++ b/UI/pom.xml
@@ -1,78 +1,83 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.capitalone.dashboard</groupId>
-	<artifactId>UI</artifactId>
-	<packaging>pom</packaging>
-	<version>0.1.1</version>
-	<name>UI</name>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.capitalone.dashboard</groupId>
+  <artifactId>UI</artifactId>
+  <packaging>pom</packaging>
+  <version>0.1.1</version>
+  <name>${project.groupId}:${project.artifactId}</name>
+  <description>Hygieia UI module</description>
+  <url>https://github.com/capitalone/Hygieia</url>
+
+  <parent>
+    <groupId>com.capitalone.dashboard</groupId>
+    <artifactId>Hygieia</artifactId>
+    <version>1.0</version>
+  </parent>
+	
   <build>
-		<plugins>
-<plugin>
-	<groupId>com.github.eirslett</groupId>
-	        <artifactId>frontend-maven-plugin</artifactId>
-	        <version>0.0.23</version>
+    <plugins>
+      <plugin>
+        <groupId>com.github.eirslett</groupId>
+        <artifactId>frontend-maven-plugin</artifactId>
+        <version>0.0.23</version>
 
-					<configuration>
-					        <workingDirectory>./</workingDirectory>
-					    </configuration>
+        <configuration>
+          <workingDirectory>./</workingDirectory>
+        </configuration>
 
-					<executions>
+        <executions>
 
-									 <execution>
-											 <id>install node and npm</id>
-											 <goals>
-													 <goal>install-node-and-npm</goal>
-											 </goals>
-											 <configuration>
-													 <nodeVersion>v0.12.0</nodeVersion>
-													 <npmVersion>2.7.1</npmVersion>
-											 </configuration>
-									 </execution>
+          <execution>
+            <id>install node and npm</id>
+            <goals>
+              <goal>install-node-and-npm</goal>
+            </goals>
+            <configuration>
+              <nodeVersion>v0.12.0</nodeVersion>
+              <npmVersion>2.7.1</npmVersion>
+            </configuration>
+          </execution>
 
-									 <execution>
-											 <id>npm install</id>
-											 <goals>
-													 <goal>npm</goal>
-											 </goals>
-											 <!-- Optional configuration which provides for running any npm command -->
-											 <configuration>
-													 <arguments>install</arguments>
-											 </configuration>
-									 </execution>
+          <execution>
+            <id>npm install</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+<!-- Optional configuration which provides for running any npm command -->
+            <configuration>
+              <arguments>install</arguments>
+            </configuration>
+          </execution>
 
-									 <execution>
-											 <id>bower install</id>
-											 <goals>
-													 <goal>bower</goal>
-											 </goals>
-											 <configuration>
-													 <arguments>install</arguments>
-											 </configuration>
-									 </execution>
+          <execution>
+            <id>bower install</id>
+            <goals>
+              <goal>bower</goal>
+            </goals>
+            <configuration>
+              <arguments>install</arguments>
+            </configuration>
+          </execution>
 
+          <execution>
+            <id>gulp build</id>
+            <goals>
+              <goal>gulp</goal>
+            </goals>
 
-									 <execution>
-    <id>gulp build</id>
-    <goals>
-        <goal>gulp</goal>
-    </goals>
+<!-- optional: the default phase is "generate-resources" -->
+            <phase>generate-resources</phase>
 
-    <!-- optional: the default phase is "generate-resources" -->
-    <phase>generate-resources</phase>
-
-    <configuration>
-        <!-- optional: if not specified, it will run gulp's default
+            <configuration>
+<!-- optional: if not specified, it will run gulp's default
         task (and you can remove this whole <configuration> section.) -->
-        <arguments>build</arguments>
-    </configuration>
-</execution>
+              <arguments>build</arguments>
+            </configuration>
+          </execution>
 
+        </executions>
 
-
-	 </executions>
-
-</plugin>
-</plugins>
-</build>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/VersionOneFeatureCollector/pom.xml
+++ b/VersionOneFeatureCollector/pom.xml
@@ -6,7 +6,17 @@
 	<artifactId>versionone-feature-collector</artifactId>
 	<packaging>jar</packaging>
 	<version>1.3.0</version>
-	<name>VersionOne Feature Collector</name>
+	<name>${project.groupId}:${project.artifactId}</name>
+  <description>VersionOne Collector Microservices</description>
+  <url>https://github.com/capitalone/Hygieia</url>
+
+	<parent>
+		<groupId>com.capitalone.dashboard</groupId>
+		<artifactId>Hygieia</artifactId>
+		<version>1.0</version>
+	</parent>
+
+
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -15,28 +25,16 @@
 		<final.name>versionone-feature-collector</final.name>
 	</properties>
 
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.2.1.RELEASE</version>
-	</parent>
-
-	<scm>
-		<connection></connection>
-		<developerConnection></developerConnection>
-		<url></url>
-		<tag>HEAD</tag>
-	</scm>
 
 	<distributionManagement>
-		<repository>
-			<id>nexus</id>
-			<url></url>
-		</repository>
 		<snapshotRepository>
-			<id>nexus</id>
-			<url></url>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 		</snapshotRepository>
+		<repository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+		</repository>
 	</distributionManagement>
 
 	<!-- Package as an executable jar -->
@@ -46,18 +44,6 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.3</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>nexus</serverId>
-					<nexusUrl></nexusUrl>
-					<stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-					<stagingProgressPauseDurationSeconds>15</stagingProgressPauseDurationSeconds>
-				</configuration>
 			</plugin>
 		</plugins>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,302 +1,295 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.capitalone.dashboard</groupId>
-	<artifactId>rest-api</artifactId>
-	<packaging>war</packaging>
-	<version>0.3.0</version>
-	<name>DevOps Dashboard REST API</name>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.capitalone.dashboard</groupId>
+  <artifactId>rest-api</artifactId>
+  <packaging>war</packaging>
+  <version>0.3.0</version>
+  <name>${project.groupId}:${project.artifactId}</name>
+  <description>Hygieia Rest API Layer</description>
+  <url>https://github.com/capitalone/Hygieia</url>
 
-	<properties>
-		<spring.version>4.1.0.RELEASE</spring.version>
-		<jackson.version>2.5.0</jackson.version>
-		<guava.version>16.0.1</guava.version>
-	</properties>
-	<scm>
-		<connection></connection>
-		<developerConnection></developerConnection>
-		<url></url>
-		<tag></tag>
-	</scm>
-	<distributionManagement>
-		<repository>
-			<id>nexus</id>
-			<url></url>
-		</repository>
-		<snapshotRepository>
-			<id>nexus</id>
-			<url></url>
-		</snapshotRepository>
-	</distributionManagement>
-	<build>
-		<finalName>api</finalName>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
-					<encoding>UTF-8</encoding>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.3</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>nexus</serverId>
-					<nexusUrl></nexusUrl>
-					<stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-					<stagingProgressPauseDurationSeconds>15</stagingProgressPauseDurationSeconds>
-				</configuration>
-			</plugin>
-			<plugin>
-  <groupId>org.jacoco</groupId>
-  <artifactId>jacoco-maven-plugin</artifactId>
-  <version>0.5.8.201207111220</version>
-  <executions>
-    <execution>
-      <goals>
-        <goal>prepare-agent</goal>
-      </goals>
-    </execution>
-    <execution>
-      <id>report</id>
-      <phase>test</phase>
-      <goals>
-        <goal>report</goal>
-      </goals>
-    </execution>
-  </executions>
-</plugin>
+  <parent>
+    <groupId>com.capitalone.dashboard</groupId>
+    <artifactId>Hygieia</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <properties>
+    <spring.version>4.1.0.RELEASE</spring.version>
+    <jackson.version>2.5.0</jackson.version>
+    <guava.version>16.0.1</guava.version>
+  </properties>
 
 
-<plugin>
-  <groupId>org.eclipse.jetty</groupId>
-  <artifactId>jetty-maven-plugin</artifactId>
-  <version>9.3.2.v20150730</version>
-	<configuration>
-    <systemProperties>
-      <systemProperty>
-         <name>dashboard.prop</name>
-         <value>${PROP_FILE}</value>
-       </systemProperty>
-    </systemProperties>
-    <webApp>
-      <contextPath>/api</contextPath>
-    </webApp>
-   </configuration>
-</plugin>
 
-	</plugins>
-	</build>
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
 
-	<dependencies>
 
-		<!-- Project Deps -->
-		<dependency>
-			<groupId>com.capitalone.dashboard</groupId>
-			<artifactId>core</artifactId>
-			<version>0.4.1</version>
-		</dependency>
+  <build>
+    <finalName>api</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.5.8.201207111220</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
 
-		<!-- Oracle Java Libraries -->
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
-			<version>3.0.1</version>
-			<scope>provided</scope>
-		</dependency>
+      <plugin>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.3.2.v20150730</version>
+        <configuration>
+          <systemProperties>
+            <systemProperty>
+              <name>dashboard.prop</name>
+              <value>${PROP_FILE}</value>
+            </systemProperty>
+          </systemProperties>
+          <webApp>
+            <contextPath>/api</contextPath>
+          </webApp>
+        </configuration>
+      </plugin>
 
-		<!-- Spring Libraries -->
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-aop</artifactId>
-			<version>${spring.version}</version>
-			<scope>compile</scope>
-		</dependency>
+    </plugins>
+  </build>
 
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-beans</artifactId>
-			<version>${spring.version}</version>
-			<scope>compile</scope>
-		</dependency>
+  <dependencies>
 
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
-			<version>${spring.version}</version>
-			<scope>compile</scope>
-		</dependency>
+<!-- Project Deps -->
+    <dependency>
+      <groupId>com.capitalone.dashboard</groupId>
+      <artifactId>core</artifactId>
+      <version>0.4.1</version>
+    </dependency>
 
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context-support</artifactId>
-			<version>${spring.version}</version>
-			<scope>compile</scope>
-		</dependency>
+<!-- Oracle Java Libraries -->
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.0.1</version>
+      <scope>provided</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-core</artifactId>
-			<version>${spring.version}</version>
-			<scope>compile</scope>
-		</dependency>
+<!-- Spring Libraries -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aop</artifactId>
+      <version>${spring.version}</version>
+      <scope>compile</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-expression</artifactId>
-			<version>${spring.version}</version>
-			<scope>compile</scope>
-		</dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+      <version>${spring.version}</version>
+      <scope>compile</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-jdbc</artifactId>
-			<version>${spring.version}</version>
-		</dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>${spring.version}</version>
+      <scope>compile</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-tx</artifactId>
-			<version>${spring.version}</version>
-		</dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context-support</artifactId>
+      <version>${spring.version}</version>
+      <scope>compile</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-web</artifactId>
-			<version>${spring.version}</version>
-			<scope>compile</scope>
-		</dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>${spring.version}</version>
+      <scope>compile</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-webmvc</artifactId>
-			<version>${spring.version}</version>
-		</dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-expression</artifactId>
+      <version>${spring.version}</version>
+      <scope>compile</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>javax.validation</groupId>
-			<artifactId>validation-api</artifactId>
-			<version>1.1.0.Final</version>
-		</dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+      <version>${spring.version}</version>
+    </dependency>
 
-		<dependency>
-			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-validator</artifactId>
-			<version>5.1.3.Final</version>
-		</dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+      <version>${spring.version}</version>
+    </dependency>
 
-		<dependency>
-			<groupId>javax.el</groupId>
-			<artifactId>javax.el-api</artifactId>
-			<version>3.0.0</version>
-			<scope>provided</scope>
-		</dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>${spring.version}</version>
+      <scope>compile</scope>
+    </dependency>
 
-		<!-- Jackson -->
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>${jackson.version}</version>
-		</dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
+      <version>${spring.version}</version>
+    </dependency>
 
-		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-core-asl</artifactId>
-			<version>1.9.13</version>
-		</dependency>
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <version>1.1.0.Final</version>
+    </dependency>
 
-		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-mapper-asl</artifactId>
-			<version>1.9.13</version>
-		</dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <version>5.1.3.Final</version>
+    </dependency>
 
-		<!--<dependency> -->
-		<!--<groupId>com.fasterxml.jackson.core</groupId> -->
-		<!--<artifactId>jackson-core</artifactId> -->
-		<!--<version>${jackson.version}</version> -->
-		<!--</dependency> -->
+    <dependency>
+      <groupId>javax.el</groupId>
+      <artifactId>javax.el-api</artifactId>
+      <version>3.0.0</version>
+      <scope>provided</scope>
+    </dependency>
 
-		<!--<dependency> -->
-		<!--<groupId>com.googlecode.json-simple</groupId> -->
-		<!--<artifactId>json-simple</artifactId> -->
-		<!--<version>1.1</version> -->
-		<!--</dependency> -->
+<!-- Jackson -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
 
-		<!-- Logging dependencies> -->
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-			<version>1.0.3</version>
-		</dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-core-asl</artifactId>
+      <version>1.9.13</version>
+    </dependency>
 
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-core</artifactId>
-			<version>1.0.3</version>
-		</dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-asl</artifactId>
+      <version>1.9.13</version>
+    </dependency>
 
-		<!-- Misc Deps -->
-		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.6</version>
-		</dependency>
+<!--<dependency> -->
+<!--<groupId>com.fasterxml.jackson.core</groupId> -->
+<!--<artifactId>jackson-core</artifactId> -->
+<!--<version>${jackson.version}</version> -->
+<!--</dependency> -->
 
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
-		</dependency>
+<!--<dependency> -->
+<!--<groupId>com.googlecode.json-simple</groupId> -->
+<!--<artifactId>json-simple</artifactId> -->
+<!--<version>1.1</version> -->
+<!--</dependency> -->
 
-		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-			<version>2.7</version>
-		</dependency>
+<!-- Logging dependencies> -->
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.0.3</version>
+    </dependency>
 
-		<!-- Test Deps -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.11</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<version>1.10.19</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-all</artifactId>
-			<version>1.3</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-test</artifactId>
-			<version>3.2.13.RELEASE</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.jayway.jsonpath</groupId>
-			<artifactId>json-path</artifactId>
-			<version>0.8.1</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.jayway.jsonpath</groupId>
-			<artifactId>json-path-assert</artifactId>
-			<version>0.8.1</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <version>1.0.3</version>
+    </dependency>
+
+<!-- Misc Deps -->
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <version>2.7</version>
+    </dependency>
+
+<!-- Test Deps -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <version>3.2.13.RELEASE</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <version>0.8.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path-assert</artifactId>
+      <version>0.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -1,43 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.capitalone.dashboard</groupId>
-	<artifactId>core</artifactId>
-	<version>0.4.1</version>
-	<packaging>jar</packaging>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.capitalone.dashboard</groupId>
+  <artifactId>core</artifactId>
+  <version>0.4.1</version>
+  <packaging>jar</packaging>
+  <name>${project.groupId}:${project.artifactId}</name>
+  <description>Core package shared by API layer and Microservices</description>
+  <url>https://github.com/capitalone/Hygieia</url>
 
-	<name>DevOps Dashboard Core Library</name>
+  <parent>
+    <groupId>com.capitalone.dashboard</groupId>
+    <artifactId>Hygieia</artifactId>
+    <version>1.0</version>
+  </parent>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>1.7</java.version>
-		<plugin.compiler.version>3.0</plugin.compiler.version>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <java.version>1.7</java.version>
+    <plugin.compiler.version>3.0</plugin.compiler.version>
 
-		<spring.version>4.1.0.RELEASE</spring.version>
-		<spring.data.version>1.6.0.RELEASE</spring.data.version>
+    <spring.version>4.1.0.RELEASE</spring.version>
+    <spring.data.version>1.6.0.RELEASE</spring.data.version>
+    <junit.version>4.11</junit.version>
+    <hamcrest.version>1.3</hamcrest.version>
+  </properties>
 
-		<junit.version>4.11</junit.version>
-		<hamcrest.version>1.3</hamcrest.version>
-	</properties>
-	<scm>
-		<connection></connection>
-		<developerConnection></developerConnection>
-		<url></url>
-		<tag></tag>
-	</scm>
-	<distributionManagement>
-		<repository>
-			<id>nexus</id>
-			<url></url>
-		</repository>
-		<snapshotRepository>
-			<id>nexus</id>
-			<url></url>
-		</snapshotRepository>
-	</distributionManagement>
-	<build>
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
+  <build>
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
@@ -64,93 +65,80 @@
 					</execution>
 				</executions>
 			</plugin>
-
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.3</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>nexus</serverId>
-					<nexusUrl>https://nexus.kdc.capitalone.com/mother</nexusUrl>
-					<stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-					<stagingProgressPauseDurationSeconds>15</stagingProgressPauseDurationSeconds>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 
-	<dependencies>
-		<!-- apache commons -->
-		<dependency>
-			<groupId>commons-codec</groupId>
-			<artifactId>commons-codec</artifactId>
-			<version>1.9</version>
-		</dependency>
-		<!-- spring -->
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-core</artifactId>
-			<version>${spring.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-test</artifactId>
-			<version>${spring.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.data</groupId>
-			<artifactId>spring-data-mongodb</artifactId>
-			<version>${spring.data.version}</version>
-		</dependency>
-
-		<!-- Query DSL -->
-		<dependency>
-			<groupId>com.mysema.querydsl</groupId>
-			<artifactId>querydsl-jpa</artifactId>
-			<version>3.6.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.mysema.querydsl</groupId>
-			<artifactId>querydsl-apt</artifactId>
-			<version>3.6.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.mysema.querydsl</groupId>
-			<artifactId>querydsl-mongodb</artifactId>
-			<version>3.6.0</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.googlecode.json-simple</groupId>
-			<artifactId>json-simple</artifactId>
-			<version>1.1.1</version>
-		</dependency>
-
-		<!-- testing -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>${junit.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<version>1.10.19</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-all</artifactId>
-			<version>${hamcrest.version}</version>
-			<scope>test</scope>
-		</dependency>
+  <dependencies>
+<!-- apache commons -->
     <dependency>
-    <groupId>de.flapdoodle.embed</groupId>
-    <artifactId>de.flapdoodle.embed.mongo</artifactId>
-    <version>1.50.0</version>
-   </dependency>
-	</dependencies>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.9</version>
+    </dependency>
+<!-- spring -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>${spring.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <version>${spring.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-mongodb</artifactId>
+      <version>${spring.data.version}</version>
+    </dependency>
+
+<!-- Query DSL -->
+    <dependency>
+      <groupId>com.mysema.querydsl</groupId>
+      <artifactId>querydsl-jpa</artifactId>
+      <version>3.6.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.mysema.querydsl</groupId>
+      <artifactId>querydsl-apt</artifactId>
+      <version>3.6.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.mysema.querydsl</groupId>
+      <artifactId>querydsl-mongodb</artifactId>
+      <version>3.6.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.googlecode.json-simple</groupId>
+      <artifactId>json-simple</artifactId>
+      <version>1.1.1</version>
+    </dependency>
+
+<!-- testing -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>de.flapdoodle.embed</groupId>
+      <artifactId>de.flapdoodle.embed.mongo</artifactId>
+      <version>1.50.0</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,16 +1,84 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                              http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.capitalone.dashboard</groupId>
-    <artifactId>Hygieia</artifactId>
-    <packaging>pom</packaging>
-    <version>1.0</version>
-    <name>Hygieia DevOps Dashboard</name>
+  <groupId>com.capitalone.dashboard</groupId>
+  <artifactId>Hygieia</artifactId>
+  <packaging>pom</packaging>
+  <version>1.0</version>
+  <name>${project.groupId}:${project.artifactId}</name>
 
-    <modules>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>1.2.1.RELEASE</version>
+  </parent>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Amit Mawkin</name>
+      <email>amit.mawkin@capitalone.com</email>
+      <organization>CapitalOne</organization>
+      <organizationUrl>http://www.capitalone.com</organizationUrl>
+    </developer>
+    <developer>
+   <name>Tapabrata Topo Pal</name>
+   <email>tapabrata.pal@capitalone.com</email>
+   <organization>CapitalOne</organization>
+   <organizationUrl>http://www.capitalone.com</organizationUrl>
+ </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/capitalone/Hygieia.git/</connection>
+    <developerConnection>scm:git:https://github.com/capitalone/Hygieia.git/</developerConnection>
+    <url>https://github.com/capitalone/Hygieia.git</url>
+  </scm>
+
+	<distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
+
+  <build>
+    <pluginManagement>
+      <plugins>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <source>1.7</source>
+            <target>1.7</target>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+
+  <profiles>
+
+    <profile>
+      <id>defaultBuild</id>
+      <activation>
+      <activeByDefault>true</activeByDefault>
+    </activation>
+      <modules>
         <module>common</module>
         <module>api</module>
         <module>BuildCollector</module>
@@ -22,20 +90,91 @@
         <module>JiraFeatureCollector</module>
         <module>JenkinsCucumberTestCollector</module>
         <module>UI</module>
-    </modules>
-
-    <build>
+      </modules>
+      <build>
         <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
-                    </configuration>
-                </plugin>
-            </plugins>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <configuration>
+                <source>1.7</source>
+                <target>1.7</target>
+              </configuration>
+            </plugin>
+          </plugins>
         </pluginManagement>
-    </build>
+      </build>
+    </profile>
+
+    <profile>
+      <id>release</id>
+      <modules>
+        <module>common</module>
+        <module>api</module>
+        <module>BuildCollector</module>
+        <module>CodeQualityCollector</module>
+        <module>SourceCodeCollector</module>
+        <module>GitHubSourceCodeCollector</module>
+        <module>VersionOneFeatureCollector</module>
+        <module>DeployCollector</module>
+        <module>JiraFeatureCollector</module>
+        <module>JenkinsCucumberTestCollector</module>
+      </modules>
+      <build>
+        <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <configuration>
+                <source>1.7</source>
+                <target>1.7</target>
+              </configuration>
+            </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>2.2.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.9.1</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
* Fixed POM's and added a release profile to be only used for releasing the binaries to Maven Central http://search.maven.org
* Fixed child parent relationship , spring-boot is extended now in parent pom and hence the collectors need not declare it as a parent.
* Fixed Embedded MongoDb test cases, they all run successfully now
* All the latest pull requests that have been merged are already released to Maven Central.

While we will be revisiting the strategy for versioning more appropriately after this.

![image](https://cloud.githubusercontent.com/assets/6624821/9700339/0b7e6734-53cd-11e5-9f89-4748fedc897b.png)
