### PR TITLE
Add Hygieia code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ We welcome Your interest in Capital One’s Open Source Projects (the “Project
 
 ##### [Link to Agreement] (https://docs.google.com/forms/d/19LpBBjykHPox18vrZvBbZUcK6gQTj7qv1O5hCduAZFU/viewform)
 
+This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to honor this code.
+[code-of-conduct]: http://todogroup.org/opencodeofconduct/#Hygieia/Hygieia@capitalone.com
 
 ### How to Start
 [Setup Instructions](https://github.com/capitalone/Hygieia/blob/master/Setup.md)


### PR DESCRIPTION
Adding a line about a code of conduct for Hygieia development. This is based on the publicly available TODO group's code of conduct.