### PR TITLE
replace absolute url links with relative links in markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ This project adheres to the [Open Code of Conduct][code-of-conduct]. By particip
 
 
 ### How to Start
-[Setup Instructions](https://github.com/capitalone/Hygieia/blob/master/Setup.md)
+[Setup Instructions](Setup.md)

--- a/Setup.md
+++ b/Setup.md
@@ -51,7 +51,7 @@ running Database and make sure that dashboarddb is created and you are successfu
 
 #### API Layer
 Please click on the link below to learn about how to build and run the API layer
-* [API](https://github.com/capitalone/Hygieia/tree/master/api)
+* [API](/api)
 
 #### Tool Collectors
 * In general all the collectors can be run using the following command
@@ -61,23 +61,23 @@ java -jar <Path to collector-name.jar> --spring.config.name=<prefix for properti
 For each individual collector setup click on the links below
 
   * **Agile Story Management**
-    * [VersionOne](https://github.com/capitalone/Hygieia/tree/master/VersionOneFeatureCollector)
-    * [Jira](https://github.com/capitalone/Hygieia/tree/master/JiraFeatureCollector)
+    * [VersionOne](versionone-feature-collector)
+    * [Jira](jira-feature-collector)
   * **Source**
-    * [GitHub](https://github.com/capitalone/Hygieia/tree/master/GitHubSourceCodeCollector)
-    * [Subversion](https://github.com/capitalone/Hygieia/tree/master/SourceCodeCollector)
+    * [GitHub](github-scm-collector)
+    * [Subversion](subversion-scm-collector)
   * **Build tools**
-    * [Jenkins/Hudson](https://github.com/capitalone/Hygieia/tree/master/BuildCollector)
+    * [Jenkins/Hudson](jenkins-build-collector)
   * **Code Quality**
-    * [Sonar](https://github.com/capitalone/Hygieia/tree/master/CodeQualityCollector)
+    * [Sonar](sonar-codequality-collector)
   * **Deployment**
-    * [uDeploy 6.x from IBM](https://github.com/capitalone/Hygieia/tree/master/DeployCollector)
+    * [uDeploy 6.x from IBM](udeploy-deployment-collector)
 
 You can pick and choose which collectors are applicable for your DevOps toolset or you can write your own collector and plug it in.
 
 #### UI Layer
 Please click on the link below to learn about how to build and run the UI layer
- * [UI](https://github.com/capitalone/Hygieia/tree/master/UI)
+ * [UI](/UI)
 
 ### Build Docker images
 

--- a/core/src/test/java/com/capitalone/dashboard/MarkdownTest.java
+++ b/core/src/test/java/com/capitalone/dashboard/MarkdownTest.java
@@ -1,0 +1,56 @@
+package com.capitalone.dashboard;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.Charset;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class MarkdownTest {
+
+    private Pattern absoluteLinkPattern = Pattern.compile(".*github.com/capitalone/Hygieia.*", Pattern.DOTALL);
+    private File root;
+
+    @Before
+    public void before(){
+        root = getProjectRoot();
+    }
+
+    @Test
+    public void licenseInRoot(){
+        File license = new File(root, "LICENSE");
+        assertTrue(license.exists());
+    }
+
+    @Test
+    public void noAbsoluteLinksInMarkdown() throws Exception {
+        Collection<File> recursiveFileList = FileUtils.listFiles(root, new String[]{"md"}, true);
+        for (File file: recursiveFileList){
+            String absolutePath = file.getAbsolutePath();
+            if(absoluteLinkPattern.matcher(fromFile(absolutePath)).matches()){
+                fail(String.format(Locale.US, "Use relative links in markdown documents: [%s]", absolutePath));
+            }
+        }
+    }
+
+    private File getProjectRoot() {
+        return new File(".").getAbsoluteFile().getParentFile().getParentFile();
+    }
+
+    CharSequence fromFile(String filename) throws IOException {
+        FileChannel channel = new FileInputStream(filename).getChannel();
+        ByteBuffer buffer = channel.map(FileChannel.MapMode.READ_ONLY, 0, (int) channel.size());
+        return Charset.forName("8859_1").newDecoder().decode(buffer);
+    }
+}


### PR DESCRIPTION
Absolute links in the markdown files didn't link correctly in branches and forks. Replaced with relative links and created junit that fails when an absolute link is included in a markdown file.