### PR TITLE
Fix for Chartist rendering issue

### DIFF
--- a/UI/src/app/css/common.less
+++ b/UI/src/app/css/common.less
@@ -724,7 +724,7 @@ tr.dash-row > td {
 #dashboard {
     background: @dash-dashboard-bg;
     color: @dash-dashboard-text;
-    overflow-x: scroll;
+    //overflow-x: scroll;
 
     // styles for chartist charts
     .ct-label {

--- a/UI/src/app/css/common.less
+++ b/UI/src/app/css/common.less
@@ -724,7 +724,6 @@ tr.dash-row > td {
 #dashboard {
     background: @dash-dashboard-bg;
     color: @dash-dashboard-text;
-    //overflow-x: scroll;
 
     // styles for chartist charts
     .ct-label {


### PR DESCRIPTION
The overflow-x: scroll on the dashboard element that was introduced in Hygieia-2 caused charts to be rendered smaller than necessary under certain conditions. 