### PR TITLE
Tech debt incorrect

### DIFF
--- a/UI/src/components/widgets/codeanalysis/view.js
+++ b/UI/src/components/widgets/codeanalysis/view.js
@@ -52,7 +52,9 @@
             ctrl.rulesCompliance = getMetric(caData.metrics, 'violations_density');
 
             ctrl.technicalDebt = getMetric(caData.metrics, 'sqale_index');
-            ctrl.technicalDebt.formattedValue = calculateTechnicalDebt(ctrl.technicalDebt.value);
+	 
+            //ctrl.technicalDebt.formattedValue = calculateTechnicalDebt(ctrl.technicalDebt.value);
+            ctrl.technicalDebt.formattedValue = ctrl.technicalDebt.formattedValue;
 
             ctrl.linesofCode = getMetric(caData.metrics, 'ncloc');
 
@@ -156,24 +158,32 @@
             return angular.extend((_.findWhere(metrics, { name: metricName }) || { name: title }), { name: title });
         }
 
+/*
         function calculateTechnicalDebt(value) {
             var factor, suffix;
+            var hour = 60;
+            var day = hour * 8;	//assume 8 hours/day 
+            var year = day * 230;	//assume 230 days = 46 work weeks (assume 2 weeks Holidays & 4 weeks vacation)
+            
             if (!value) return '-';
-            if (value < 1440) {
+            if (value < day) {
                 // hours
-                factor = 60;
+                factor = hour;
                 suffix = 'h';
-            } else if (value < 525600) {
+            } else if (value < year) {
                 // days
-                factor = 1440;
+                factor = day;
                 suffix = 'd';
             } else {
                 // years
-                factor = 525600;
+                factor = year;
                 suffix = 'y';
             }
-            return Math.ceil(value/factor) + suffix;
+		//unable to find an exact calc, but reviewing several cases it looks like the sonar UI truncates the #
+		//soi this should tie out closer to what people are seeing in SONAR UI
+            return Math.floor(value/factor) + suffix;
         }
+*/
 
         function showStatusIcon(item) {
             return item.status && item.status.toLowerCase() != 'ok';


### PR DESCRIPTION
reference #368 Code collector widget showing different tech debt value

In the current code I found 2 issues:

#1 the values in the DB returned in the rest call is in minutes, so we should be diving by 8*60 for 1d. (maybe older versions of sonar are using seconds if we find that is the case we may have to make this configurable)

#2 it appears the sonar ui is using floor() vs ceil() of the calculation, so I changed that to line up the UI's.