### PR TITLE
changed "database" to "dbname" in github docker builder and application.properties example in the readme

### DIFF
--- a/github-scm-collector/README.md
+++ b/github-scm-collector/README.md
@@ -17,7 +17,7 @@ for information about sourcing this properties file.
 ###Sample application.properties file
 --------------------------------------
     #Database Name 
-    database=dashboarddb
+    dbname=dashboarddb
 
     #Database HostName - default is localhost
     dbhost=10.0.1.1

--- a/github-scm-collector/docker/github-properties-builder.sh
+++ b/github-scm-collector/docker/github-properties-builder.sh
@@ -27,7 +27,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name
-database=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}


### PR DESCRIPTION
Got stuck in trying to get the github collector running. Fix was changing my application.properties file to identify database name as "dbname=", instead of "database=". 

I edited the readme and the docker builder for github to reflect dbname. 