### PR TITLE
Add missing Docker Containers and Fix SONAR build

### DIFF
--- a/UI/pom.xml
+++ b/UI/pom.xml
@@ -14,6 +14,24 @@
 
   <build>
     <plugins>
+	<plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+            </executions>
+        </plugin>
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
@@ -85,9 +103,9 @@
         <configuration>
 	  <skipDockerBuild>false</skipDockerBuild>
           <imageName>hygieia-ui</imageName>
+	  <skipDockerBuild>false</skipDockerBuild> 
           <dockerDirectory>${project.basedir}/docker</dockerDirectory>
           <resources>
-
              <resource>
                <targetPath>html</targetPath>
                <directory>${project.basedir}/dist</directory>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -38,34 +38,6 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-                    <encoding>UTF-8</encoding>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>${jacoco.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>com.spotify</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
@@ -80,6 +52,24 @@
                         </resource>
                     </resources>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -181,5 +171,11 @@
       <artifactId>json-path</artifactId>
       <scope>test</scope>
     </dependency>
+	<dependency>
+	    <groupId>org.joda</groupId>
+	    <artifactId>joda-convert</artifactId>
+	    <version>1.8.1</version>
+	    <scope>provided</scope>
+	</dependency>
   </dependencies>
 </project>

--- a/chat-ops-collector/docker/Dockerfile
+++ b/chat-ops-collector/docker/Dockerfile
@@ -1,0 +1,18 @@
+
+FROM docker.io/java:openjdk-8-jdk
+
+MAINTAINER Hygieia@capitalone.com
+
+RUN \
+  mkdir /hygieia
+
+COPY *.jar /hygieia/
+COPY chat-ops-properties-builder.sh /hygieia/
+
+WORKDIR /hygieia
+
+VOLUME ["/hygieia/logs"]
+
+CMD ./chat-ops-properties-builder.sh && \
+  java -jar chat-ops-collector*.jar --spring.config.location=/hygieia/hygieia-chat-ops-collector.properties
+

--- a/chat-ops-collector/docker/chat-ops-properties-builder.sh
+++ b/chat-ops-collector/docker/chat-ops-properties-builder.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# mongo container provides the HOST/PORT
+# api container provided DB Name, ID & PWD
+
+if [ "$TEST_SCRIPT" != "" ]
+then
+        #for testing locally
+        PROP_FILE=application.properties
+else 
+	PROP_FILE=hygieia-chat-ops-collector.properties
+fi
+  
+if [ "$MONGO_PORT" != "" ]; then
+	# Sample: MONGO_PORT=tcp://172.17.0.20:27017
+	MONGODB_HOST=`echo $MONGO_PORT|sed 's;.*://\([^:]*\):\(.*\);\1;'`
+	MONGODB_PORT=`echo $MONGO_PORT|sed 's;.*://\([^:]*\):\(.*\);\2;'`
+else
+	env
+	echo "ERROR: MONGO_PORT not defined"
+	exit 1
+fi
+
+echo "MONGODB_HOST: $MONGODB_HOST"
+echo "MONGODB_PORT: $MONGODB_PORT"
+
+
+cat > $PROP_FILE <<EOF
+#Database Name
+database=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+
+#Database HostName - default is localhost
+dbhost=${MONGODB_HOST:-10.0.1.1}
+
+#Database Port - default is 27017
+dbport=${MONGODB_PORT:-27017}
+
+#Database Username - default is blank
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+
+#Database Password - default is blank
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+
+#Collector schedule (required)
+chatops.cron=${CHATOPS_CRON:-5 * * * * *}
+
+EOF
+
+echo "
+
+===========================================
+Properties file created `date`:  $PROP_FILE
+Note: passwords hidden
+===========================================
+`cat $PROP_FILE |egrep -vi password`
+ "
+
+exit 0

--- a/chat-ops-collector/pom.xml
+++ b/chat-ops-collector/pom.xml
@@ -48,6 +48,25 @@
 					</resources>
 				</configuration>
 			</plugin>
+
+			    <plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<executions>
+				    <execution>
+					<goals>
+					    <goal>prepare-agent</goal>
+					</goals>
+				    </execution>
+				    <execution>
+					<id>report</id>
+					<phase>verify</phase>
+					<goals>
+					    <goal>report</goal>
+					</goals>
+				    </execution>
+				</executions>
+			    </plugin>
 		</plugins>
 
 		<testResources>
@@ -113,6 +132,12 @@
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
+		</dependency>
+		<dependency>
+		    <groupId>org.joda</groupId>
+		    <artifactId>joda-convert</artifactId>
+		    <version>1.8.1</version>
+		    <scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,9 +17,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>1.8</java.version>
-        <plugin.compiler.version>3.0</plugin.compiler.version>
-
         <spring.version>4.1.7.RELEASE</spring.version>
         <spring.data.version>1.8.0.RELEASE</spring.data.version>
         <junit.version>4.11</junit.version>
@@ -44,14 +41,6 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <groupId>com.mysema.maven</groupId>
                 <artifactId>apt-maven-plugin</artifactId>
                 <version>1.1.3</version>
@@ -65,6 +54,24 @@
                             <processor>org.springframework.data.mongodb.repository.support.MongoAnnotationProcessor
                             </processor>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>
@@ -158,5 +165,11 @@
             <artifactId>javax.el-api</artifactId>
             <version>2.2.4</version>
         </dependency>
-    </dependencies>
+	<dependency>
+	    <groupId>org.joda</groupId>
+	    <artifactId>joda-convert</artifactId>
+	    <version>1.8.1</version>
+	    <scope>provided</scope>
+	</dependency>
+   </dependencies>
 </project>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,3 +174,102 @@ hygieia-chat-ops-collector:
 #  environment:
 #  - CHATOPS_CRON=0 0/5 * * * *
 
+hygieia-subversion-scm-collector:
+  image: hygieia-subversion-scm-collector:latest
+  container_name: hygieia-subversion
+  volumes:
+  - ./logs:/hygieia/logs
+  links:
+  - mongodb:mongo
+  - hygieia-api
+#  environment:
+#  - SUBVERSION_CRON:-0 0/5 * * * *
+
+#Shared subversion username and password
+#  - SUBVERSION_USERNAME=
+#  - SUBVERSION_PASSWORD=
+
+#Maximum number of days to go back in time when fetching commits
+#  - SUBVERSION_COMMIT_THRESHOLD_DAYS=15
+
+hygieia-stash-scm-collector:
+  image: hygieia-stash-scm-collector:latest
+  container_name: hygieia-stash
+  volumes:
+  - ./logs:/hygieia/logs
+  links:
+  - mongodb:mongo
+  - hygieia-api
+#  environment:
+    #mandatory
+#  - STASH_HOST=mystashrepo.com/
+#  - STASH_API=/rest/api/1.0/
+
+#  - STASH_CRON:-0 0/5 * * * *
+
+#Maximum number of days to go back in time when fetching commits
+#  - STASH_COMMIT_THRESHOLD_DAYS=15
+
+hygieia-versionone-collector:
+  image: hygieia-versionone-collector:latest
+  container_name: hygieia-versionone
+  volumes:
+  - ./logs:/hygieia/logs
+  links:
+  - mongodb:mongo
+  - hygieia-api
+#  environment:
+#Page size for data calls (VersionOne recommended 2000)
+#  - VERSIONONE_PAGE_SIZE=2000
+
+#In-built folder housing prepared REST queries (required)
+#  - VERSIONONE_QUERY_FOLDER=v1api-queries
+
+#Jira API Query file names (String template requires the files to have .st extension) (required)
+#  - VERSIONONE_STORY_QUERY=story
+#  - VERSIONONE_EPIC_QUERY=epicinfo
+#  - VERSIONONE_PROJECT_QUERY=projectinfo
+#  - VERSIONONE_MEMBBER_QUERY=memberinfo
+#  - VERSIONONE_SPRINT_QUERY=sprintinfo
+#  - VERSIONONE_TEAM_QUERY=teaminfo
+#  - VERSIONONE_TRENDING_QUERY=trendinginfo
+
+# Trending Query:  Number of days in a sprint (not-required)
+#  - VERSIONONE_SPRINT_DAYS=60
+# Trending Query:  Length of sprint week (not-required)
+#  - VERSIONONE_SPRINT_END_PRIOR=7
+
+#Scheduled Job prior minutes to recover data created during execution time (usually, 2 minutes is enough)
+#  - VERSIONONE_SCHEDULED_PRIOR_MIN=2
+
+#Delta change date that modulates the collector item task - should be about as far back as possible, in ISO format (required)
+#  - VERSIONONE_DELTA_COLLECTORITEM_START_DATE=2008-01-01T00:00:00.000000
+
+#VersionOne Connection Details
+#Proxy assumes a host:port syntax
+#  - VERSIONONE_PROXY_URL=""
+#  - VERSIONONE_URL=https://www.versionone.com/our-company-instance/
+#Access token provided by VersionOne
+#  - VERSIONONE_ACCESS_TOKEN=accessToken
+
+#Start dates from which to begin collector data, if no other data is present - usually, a month back is appropriate (required)
+#  - VERSIONONE_DELTA_START_DATE=2015-03-01T00:00:00.000000
+#  - VERSIONONE_MASTER_START_DATE=2008-01-01T00:00:00.000000
+
+hygieia-udeploy-collector:
+  image: hygieia-udeploy-collector:latest
+  container_name: hygieia-udeploy
+  volumes:
+  - ./logs:/hygieia/logs
+  links:
+  - mongodb:mongo
+  - hygieia-api
+  environment:
+#UDeploy server (required) - Can provide multiple
+  - UDEPLOY_URL:-http://udeploy.company.com
+#UDeploy user name (required)
+  - UDEPLOY_USERNAME:-bobama
+#UDeploy password (required)
+  - UDEPLOY_PASSWORD:-s3cr3t
+#Collector schedule (required)
+#  - UDEPLOY_CRON:-0 0/5 * * * *

--- a/github-scm-collector/pom.xml
+++ b/github-scm-collector/pom.xml
@@ -48,6 +48,24 @@
 					</resources>
 				</configuration>
 			</plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 		</plugins>
 
 		<testResources>
@@ -58,6 +76,7 @@
 	</build>
 
 	<properties>
+		<sonar.skip>true</sonar.skip>
 		<java.version>1.8</java.version>
 	</properties>
 
@@ -114,6 +133,12 @@
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
+		</dependency>
+		<dependency>
+		    <groupId>org.joda</groupId>
+		    <artifactId>joda-convert</artifactId>
+		    <version>${joda-convert.version}</version>
+		    <scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/github-scm-collector/src/main/java/com/capitalone/dashboard/collector/DefaultGitHubClient.java
+++ b/github-scm-collector/src/main/java/com/capitalone/dashboard/collector/DefaultGitHubClient.java
@@ -56,8 +56,8 @@ public class DefaultGitHubClient implements GitHubClient {
 		this.restOperations = restOperationsSupplier.get();
 	}
 
-	@SuppressWarnings({"PMD.ExcessiveMethodLength", "PMD.NPathComplexity"}) // agreed, fixme
 	@Override
+	@SuppressWarnings({"PMD.NPathComplexity","PMD.ExcessiveMethodLength"}) // agreed, fixme
 	public List<Commit> getCommits(GitHubRepo repo, boolean firstRun) {
 
 		List<Commit> commits = new ArrayList<>();

--- a/hygieia-jenkins-plugin/pom.xml
+++ b/hygieia-jenkins-plugin/pom.xml
@@ -154,6 +154,24 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
 
     </build>

--- a/jenkins-build-collector/pom.xml
+++ b/jenkins-build-collector/pom.xml
@@ -48,6 +48,25 @@
 					</resources>
 				</configuration>
 			</plugin>
+
+		    <plugin>
+			<groupId>org.jacoco</groupId>
+			<artifactId>jacoco-maven-plugin</artifactId>
+			<executions>
+			    <execution>
+				<goals>
+				    <goal>prepare-agent</goal>
+				</goals>
+			    </execution>
+			    <execution>
+				<id>report</id>
+				<phase>verify</phase>
+				<goals>
+				    <goal>report</goal>
+				</goals>
+			    </execution>
+			</executions>
+		    </plugin>
 		</plugins>
 
 		<testResources>

--- a/jenkins-cucumber-test-collector/pom.xml
+++ b/jenkins-cucumber-test-collector/pom.xml
@@ -47,6 +47,25 @@
 					</resources>
 				</configuration>
 			</plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 		</plugins>
 
 		<testResources>

--- a/jira-feature-collector/pom.xml
+++ b/jira-feature-collector/pom.xml
@@ -89,6 +89,25 @@
 					</resources>
 				</configuration>
 			</plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 		</plugins>
 
 		<testResources>

--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,10 @@
 		<spring.version>4.1.7.RELEASE</spring.version>
 		<jackson.version>2.5.0</jackson.version>
 		<guava.version>16.0.1</guava.version>
-		<pmd.version>3.5</pmd.version>
-		<jacoco.version>0.7.5.201505241946</jacoco.version>
+		<pmd.version>3.6</pmd.version>
+		<jacoco.version>0.7.6.201602180812</jacoco.version>
 		<joda-time.version>2.7</joda-time.version>
+		<joda-convert.version>1.8.1</joda-convert.version>
 	</properties>
 
   <licenses>
@@ -118,17 +119,41 @@
 					<version>0.4.0</version>
 				</plugin>
 				<plugin>
-					<groupId>org.codehaus.sonar</groupId>
+					<groupId>org.codehaus.mojo</groupId>
+<!--
+					<groupId>org.sonarsource.scanner.maven</groupId>
+-->
 					<artifactId>sonar-maven-plugin</artifactId>
-					<version>4.5.6</version>
+					<version>3.0.1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
+						<version>3.5.1</version>
 					<configuration>
 						<source>1.8</source>
 						<target>1.8</target>
 					</configuration>
+				</plugin>
+
+				<plugin>
+					<groupId>org.jacoco</groupId>
+					<artifactId>jacoco-maven-plugin</artifactId>
+					<version>${jacoco.version}</version> 
+					<executions>
+					    <execution>
+						<goals>
+						    <goal>prepare-agent</goal>
+						</goals>
+					    </execution>
+					    <execution>
+						<id>report</id>
+						<phase>verify</phase>
+						<goals>
+						    <goal>report</goal>
+						</goals>
+					    </execution>
+					</executions>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -147,6 +172,7 @@
 				<module>sonar-codequality-collector</module>
 				<module>subversion-scm-collector</module>
 				<module>github-scm-collector</module>
+				<module>stash-scm-collector</module>
 				<module>versionone-feature-collector</module>
 				<module>udeploy-deployment-collector</module>
 				<module>jira-feature-collector</module>
@@ -160,6 +186,7 @@
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-compiler-plugin</artifactId>
+						<version>3.5.1</version>
 							<configuration>
 								<source>1.8</source>
 								<target>1.8</target>
@@ -190,6 +217,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
+						<version>3.5.1</version>
 						<configuration>
 							<source>1.8</source>
 							<target>1.8</target>

--- a/sonar-codequality-collector/pom.xml
+++ b/sonar-codequality-collector/pom.xml
@@ -48,6 +48,25 @@
 					</resources>
 				</configuration>
 			</plugin>
+
+		    <plugin>
+			<groupId>org.jacoco</groupId>
+			<artifactId>jacoco-maven-plugin</artifactId>
+			<executions>
+			    <execution>
+				<goals>
+				    <goal>prepare-agent</goal>
+				</goals>
+			    </execution>
+			    <execution>
+				<id>report</id>
+				<phase>verify</phase>
+				<goals>
+				    <goal>report</goal>
+				</goals>
+			    </execution>
+			</executions>
+		    </plugin>
 		</plugins>
 		<testResources>
 			<testResource>

--- a/stash-scm-collector/docker/Dockerfile
+++ b/stash-scm-collector/docker/Dockerfile
@@ -1,0 +1,18 @@
+
+FROM docker.io/java:openjdk-8-jdk
+
+MAINTAINER Hygieia@capitalone.com
+
+RUN \
+  mkdir /hygieia
+
+COPY *.jar /hygieia/
+COPY stash-properties-builder.sh /hygieia/
+
+WORKDIR /hygieia
+
+VOLUME ["/hygieia/logs"]
+
+CMD ./stash-properties-builder.sh && \
+  java -jar stash-scm-collector*.jar --spring.config.location=/hygieia/hygieia-stash-scm-collector.properties
+

--- a/stash-scm-collector/docker/stash-properties-builder.sh
+++ b/stash-scm-collector/docker/stash-properties-builder.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# mongo container provides the HOST/PORT
+# api container provided DB Name, ID & PWD
+
+if [ "$TEST_SCRIPT" != "" ]
+then
+        #for testing locally
+        PROP_FILE=application.properties
+else 
+	PROP_FILE=hygieia-stash-scm-collector.properties
+fi
+  
+if [ "$MONGO_PORT" != "" ]; then
+	# Sample: MONGO_PORT=tcp://172.17.0.20:27017
+	MONGODB_HOST=`echo $MONGO_PORT|sed 's;.*://\([^:]*\):\(.*\);\1;'`
+	MONGODB_PORT=`echo $MONGO_PORT|sed 's;.*://\([^:]*\):\(.*\);\2;'`
+else
+	env
+	echo "ERROR: MONGO_PORT not defined"
+	exit 1
+fi
+
+echo "MONGODB_HOST: $MONGODB_HOST"
+echo "MONGODB_PORT: $MONGODB_PORT"
+
+
+cat > $PROP_FILE <<EOF
+#Database Name
+database=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+
+#Database HostName - default is localhost
+dbhost=${MONGODB_HOST:-10.0.1.1}
+
+#Database Port - default is 27017
+dbport=${MONGODB_PORT:-27017}
+
+#Database Username - default is blank
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+
+#Database Password - default is blank
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+
+#Collector schedule (required)
+git.cron=${STASH_CRON:-0 0/5 * * * *}
+
+    #mandatory
+git.host=${STASH_HOST:-mystashrepo.com/}
+git.api=${STASH_API:-/rest/api/1.0/}
+
+#Maximum number of days to go back in time when fetching commits
+git.commitThresholdDays=${STASH_COMMIT_THRESHOLD_DAYS:-15}
+
+EOF
+
+echo "
+
+===========================================
+Properties file created `date`:  $PROP_FILE
+Note: passwords hidden
+===========================================
+`cat $PROP_FILE |egrep -vi password`
+ "
+
+exit 0

--- a/stash-scm-collector/pom.xml
+++ b/stash-scm-collector/pom.xml
@@ -32,6 +32,42 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+
+			<plugin>
+				<groupId>com.spotify</groupId>
+				<artifactId>docker-maven-plugin</artifactId>
+				<configuration>
+					<skipDockerBuild>false</skipDockerBuild>
+					<imageName>hygieia-stash-scm-collector</imageName>
+					<dockerDirectory>${project.basedir}/docker</dockerDirectory>
+					<resources>
+						<resource>
+							<targetPath>/</targetPath>
+							<directory>${project.build.directory}</directory>
+							<include>${project.build.finalName}.jar</include>
+						</resource>
+					</resources>
+				</configuration>
+			</plugin>
+
+		    <plugin>
+			<groupId>org.jacoco</groupId>
+			<artifactId>jacoco-maven-plugin</artifactId>
+			<executions>
+			    <execution>
+				<goals>
+				    <goal>prepare-agent</goal>
+				</goals>
+			    </execution>
+			    <execution>
+				<id>report</id>
+				<phase>verify</phase>
+				<goals>
+				    <goal>report</goal>
+				</goals>
+			    </execution>
+			</executions>
+		    </plugin>
 		</plugins>
 
 		<testResources>
@@ -42,6 +78,7 @@
 	</build>
 
 	<properties>
+		<sonar.skip>true</sonar.skip>
 		<java.version>1.8</java.version>
 	</properties>
 
@@ -100,6 +137,12 @@
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
+		</dependency>
+		<dependency>
+		    <groupId>org.joda</groupId>
+		    <artifactId>joda-convert</artifactId>
+		    <version>${joda-convert.version}</version>
+		    <scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/subversion-scm-collector/docker/Dockerfile
+++ b/subversion-scm-collector/docker/Dockerfile
@@ -1,0 +1,18 @@
+
+FROM docker.io/java:openjdk-8-jdk
+
+MAINTAINER Hygieia@capitalone.com
+
+RUN \
+  mkdir /hygieia
+
+COPY *.jar /hygieia/
+COPY subversion-properties-builder.sh /hygieia/
+
+WORKDIR /hygieia
+
+VOLUME ["/hygieia/logs"]
+
+CMD ./subversion-properties-builder.sh && \
+  java -jar subversion-collector*.jar --spring.config.location=/hygieia/hygieia-subversion-collector.properties
+

--- a/subversion-scm-collector/docker/subversion-properties-builder.sh
+++ b/subversion-scm-collector/docker/subversion-properties-builder.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# mongo container provides the HOST/PORT
+# api container provided DB Name, ID & PWD
+
+if [ "$TEST_SCRIPT" != "" ]
+then
+        #for testing locally
+        PROP_FILE=application.properties
+else 
+	PROP_FILE=hygieia-subversion-collector.properties
+fi
+  
+if [ "$MONGO_PORT" != "" ]; then
+	# Sample: MONGO_PORT=tcp://172.17.0.20:27017
+	MONGODB_HOST=`echo $MONGO_PORT|sed 's;.*://\([^:]*\):\(.*\);\1;'`
+	MONGODB_PORT=`echo $MONGO_PORT|sed 's;.*://\([^:]*\):\(.*\);\2;'`
+else
+	env
+	echo "ERROR: MONGO_PORT not defined"
+	exit 1
+fi
+
+echo "MONGODB_HOST: $MONGODB_HOST"
+echo "MONGODB_PORT: $MONGODB_PORT"
+
+
+cat > $PROP_FILE <<EOF
+#Database Name
+database=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+
+#Database HostName - default is localhost
+dbhost=${MONGODB_HOST:-10.0.1.1}
+
+#Database Port - default is 27017
+dbport=${MONGODB_PORT:-27017}
+
+#Database Username - default is blank
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+
+#Database Password - default is blank
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+
+#Collector schedule (required)
+subversion.cron=${SUBVERSION_CRON:-0 0/5 * * * *}
+
+#Shared subversion username and password
+subversion.username=${SUBVERSION_USERNAME:-foo}
+subversion.password=${SUBVERSION_PASSWORD:-bar}
+
+#Maximum number of days to go back in time when fetching commits
+subversion.commitThresholdDays=${SUBVERSION_COMMIT_THRESHOLD_DAYS:-15}
+
+EOF
+
+echo "
+
+===========================================
+Properties file created `date`:  $PROP_FILE
+Note: passwords hidden
+===========================================
+`cat $PROP_FILE |egrep -vi password`
+ "
+
+exit 0

--- a/subversion-scm-collector/pom.xml
+++ b/subversion-scm-collector/pom.xml
@@ -31,6 +31,42 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+
+			<plugin>
+				<groupId>com.spotify</groupId>
+				<artifactId>docker-maven-plugin</artifactId>
+				<configuration>
+					<skipDockerBuild>false</skipDockerBuild>
+					<imageName>hygieia-subversion-scm-collector</imageName>
+					<dockerDirectory>${project.basedir}/docker</dockerDirectory>
+					<resources>
+						<resource>
+							<targetPath>/</targetPath>
+							<directory>${project.build.directory}</directory>
+							<include>${project.build.finalName}.jar</include>
+						</resource>
+					</resources>
+				</configuration>
+			</plugin>
+
+		    <plugin>
+			<groupId>org.jacoco</groupId>
+			<artifactId>jacoco-maven-plugin</artifactId>
+			<executions>
+			    <execution>
+				<goals>
+				    <goal>prepare-agent</goal>
+				</goals>
+			    </execution>
+			    <execution>
+				<id>report</id>
+				<phase>verify</phase>
+				<goals>
+				    <goal>report</goal>
+				</goals>
+			    </execution>
+			</executions>
+		    </plugin>
 		</plugins>
 
 		<testResources>
@@ -86,7 +122,12 @@
 			<version>2.4</version>
 			<scope>test</scope>
 		</dependency>
-
-	</dependencies>
+		<dependency>
+		    <groupId>org.joda</groupId>
+		    <artifactId>joda-convert</artifactId>
+		    <version>1.8.1</version>
+		    <scope>provided</scope>
+		</dependency>
+			</dependencies>
 
 </project>

--- a/test-servers/jenkins/Dockerfile
+++ b/test-servers/jenkins/Dockerfile
@@ -16,12 +16,12 @@ ENV MAVEN_HOME /usr/share/maven
 
 
 #Create a log for jenkins (best practice) per Maxfield Stewart
-RUN mkdir /var/log/jenkins
-RUN chown -R jenkins:jenkins /var/log/jenkins
-RUN mkdir /var/cache/jenkins
-RUN chown -R jenkins:jenkins /var/cache/jenkins
-ENV JAVA_OPTS -Xmx8192m
-ENV JENKINS_OPTS --handlerCountStartup=100 --handlerCountMax=300 --logfile=/var/log/jenkins/jenkins.log  --webroot=/var/cache/jenkins/war
+#RUN mkdir /var/log/jenkins
+#RUN chown -R jenkins:jenkins /var/log/jenkins
+#RUN mkdir /var/cache/jenkins
+#RUN chown -R jenkins:jenkins /var/cache/jenkins
+#ENV JAVA_OPTS -Xmx8192m
+#ENV JENKINS_OPTS --handlerCountStartup=100 --handlerCountMax=300 --logfile=/var/log/jenkins/jenkins.log  --webroot=/var/cache/jenkins/war
 
 
 #setup plugins

--- a/test-servers/sonar/sonar.yml
+++ b/test-servers/sonar/sonar.yml
@@ -1,6 +1,6 @@
 
 sonarqube:
-  image: sonarqube:5.1
+  image: sonarqube:5.3
   ports:
    - "9000:9000"
    - "9092:9092"

--- a/udeploy-deployment-collector/docker/Dockerfile
+++ b/udeploy-deployment-collector/docker/Dockerfile
@@ -1,0 +1,18 @@
+
+FROM docker.io/java:openjdk-8-jdk
+
+MAINTAINER Hygieia@capitalone.com
+
+RUN \
+  mkdir /hygieia
+
+COPY *.jar /hygieia/
+COPY udeploy-properties-builder.sh /hygieia/
+
+WORKDIR /hygieia
+
+VOLUME ["/hygieia/logs"]
+
+CMD ./udeploy-properties-builder.sh && \
+  java -jar udeploy-deployment-collector*.jar --spring.config.location=/hygieia/hygieia-udeploy-deployment-collector.properties
+

--- a/udeploy-deployment-collector/docker/udeploy-properties-builder.sh
+++ b/udeploy-deployment-collector/docker/udeploy-properties-builder.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# mongo container provides the HOST/PORT
+# api container provided DB Name, ID & PWD
+
+if [ "$TEST_SCRIPT" != "" ]
+then
+        #for testing locally
+        PROP_FILE=application.properties
+else 
+	PROP_FILE=hygieia-udeploy-deployment-collector.properties
+fi
+  
+if [ "$MONGO_PORT" != "" ]; then
+	# Sample: MONGO_PORT=tcp://172.17.0.20:27017
+	MONGODB_HOST=`echo $MONGO_PORT|sed 's;.*://\([^:]*\):\(.*\);\1;'`
+	MONGODB_PORT=`echo $MONGO_PORT|sed 's;.*://\([^:]*\):\(.*\);\2;'`
+else
+	env
+	echo "ERROR: MONGO_PORT not defined"
+	exit 1
+fi
+
+echo "MONGODB_HOST: $MONGODB_HOST"
+echo "MONGODB_PORT: $MONGODB_PORT"
+
+
+cat > $PROP_FILE <<EOF
+#Database Name
+database=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+
+#Database HostName - default is localhost
+dbhost=${MONGODB_HOST:-10.0.1.1}
+
+#Database Port - default is 27017
+dbport=${MONGODB_PORT:-27017}
+
+#Database Username - default is blank
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+
+#Database Password - default is blank
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+
+#Collector schedule (required)
+udeploy.cron=${UDEPLOY_CRON:-0 0/5 * * * *}
+
+#UDeploy server (required) - Can provide multiple
+udeploy.servers[0]=${UDEPLOY_URL:-http://udeploy.company.com}
+
+#UDeploy user name (required)
+udeploy.username=${UDEPLOY_USERNAME:-bobama}
+
+#UDeploy password (required)
+udeploy.password=${UDEPLOY_PASSWORD:-s3cr3t}
+
+EOF
+
+echo "
+
+===========================================
+Properties file created `date`:  $PROP_FILE
+Note: passwords hidden
+===========================================
+`cat $PROP_FILE |egrep -vi password`
+ "
+
+exit 0

--- a/udeploy-deployment-collector/pom.xml
+++ b/udeploy-deployment-collector/pom.xml
@@ -32,6 +32,42 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+
+			<plugin>
+				<groupId>com.spotify</groupId>
+				<artifactId>docker-maven-plugin</artifactId>
+				<configuration>
+					<skipDockerBuild>false</skipDockerBuild>
+					<imageName>hygieia-udeploy-collector</imageName>
+					<dockerDirectory>${project.basedir}/docker</dockerDirectory>
+					<resources>
+						<resource>
+							<targetPath>/</targetPath>
+							<directory>${project.build.directory}</directory>
+							<include>${project.build.finalName}.jar</include>
+						</resource>
+					</resources>
+				</configuration>
+			</plugin>
+
+		    <plugin>
+			<groupId>org.jacoco</groupId>
+			<artifactId>jacoco-maven-plugin</artifactId>
+			<executions>
+			    <execution>
+				<goals>
+				    <goal>prepare-agent</goal>
+				</goals>
+			    </execution>
+			    <execution>
+				<id>report</id>
+				<phase>verify</phase>
+				<goals>
+				    <goal>report</goal>
+				</goals>
+			    </execution>
+			</executions>
+		    </plugin>
 		</plugins>
 
 		<testResources>

--- a/versionone-feature-collector/docker/Dockerfile
+++ b/versionone-feature-collector/docker/Dockerfile
@@ -1,0 +1,18 @@
+
+FROM docker.io/java:openjdk-8-jdk
+
+MAINTAINER Hygieia@capitalone.com
+
+RUN \
+  mkdir /hygieia
+
+COPY *.jar /hygieia/
+COPY versionone-properties-builder.sh /hygieia/
+
+WORKDIR /hygieia
+
+VOLUME ["/hygieia/logs"]
+
+CMD ./versionone-properties-builder.sh && \
+  java -jar versionone-feature-collector*.jar --spring.config.location=/hygieia/hygieia-versionone-feature-collector.properties
+

--- a/versionone-feature-collector/docker/versionone-properties-builder.sh
+++ b/versionone-feature-collector/docker/versionone-properties-builder.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# mongo container provides the HOST/PORT
+# api container provided DB Name, ID & PWD
+
+if [ "$TEST_SCRIPT" != "" ]
+then
+        #for testing locally
+        PROP_FILE=application.properties
+else 
+	PROP_FILE=hygieia-versionone-feature-collector.properties
+fi
+  
+if [ "$MONGO_PORT" != "" ]; then
+	# Sample: MONGO_PORT=tcp://172.17.0.20:27017
+	MONGODB_HOST=`echo $MONGO_PORT|sed 's;.*://\([^:]*\):\(.*\);\1;'`
+	MONGODB_PORT=`echo $MONGO_PORT|sed 's;.*://\([^:]*\):\(.*\);\2;'`
+else
+	env
+	echo "ERROR: MONGO_PORT not defined"
+	exit 1
+fi
+
+echo "MONGODB_HOST: $MONGODB_HOST"
+echo "MONGODB_PORT: $MONGODB_PORT"
+
+
+cat > $PROP_FILE <<EOF
+#Database Name
+database=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+
+#Database HostName - default is localhost
+dbhost=${MONGODB_HOST:-10.0.1.1}
+
+#Database Port - default is 27017
+dbport=${MONGODB_PORT:-27017}
+
+#Database Username - default is blank
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+
+#Database Password - default is blank
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+
+#Page size for data calls (VersionOne recommended 2000)
+feature.pageSize=${VERSIONONE_PAGE_SIZE:-2000}
+
+#In-built folder housing prepared REST queries (required)
+feature.queryFolder=${VERSIONONE_QUERY_FOLDER:-v1api-queries}
+
+#Jira API Query file names (String template requires the files to have .st extension) (required)
+feature.storyQuery=${VERSIONONE_STORY_QUERY:-story}
+feature.epicQuery=${VERSIONONE_EPIC_QUERY:-epicinfo}
+feature.projectQuery=${VERSIONONE_PROJECT_QUERY:-projectinfo}
+feature.memberQuery=${VERSIONONE_MEMBBER_QUERY:-memberinfo}
+feature.sprintQuery=${VERSIONONE_SPRINT_QUERY:-sprintinfo}
+feature.teamQuery=${VERSIONONE_TEAM_QUERY:-teaminfo}
+feature.trendingQuery${{VERSIONONE_TRENDING_QUERY:-trendinginfo}
+
+# Trending Query:  Number of days in a sprint (not-required)
+feature.sprintDays=${VERSIONONE_SPRINT_DAYS:-60}
+# Trending Query:  Length of sprint week (not-required)
+feature.sprintEndPrior=${VERSIONONE_SPRINT_END_PRIOR:-7}
+
+#Scheduled Job prior minutes to recover data created during execution time (usually, 2 minutes is enough)
+feature.scheduledPriorMin=${VERSIONONE_SCHEDULED_PRIOR_MIN:-2}
+
+#Delta change date that modulates the collector item task - should be about as far back as possible, in ISO format (required)
+feature.deltaCollectorItemStartDate=${VERSIONONE_DELTA_COLLECTORITEM_START_DATE:-2008-01-01T00:00:00.000000}
+
+#VersionOne Connection Details
+#Proxy assumes a host:port syntax
+feature.versionOneProxyUrl=${VERSIONONE_PROXY_URL:-""}
+feature.versionOneBaseUri=${VERSIONONE_URL:-https://www.versionone.com/our-company-instance/}
+#Access token provided by VersionOne
+feature.versionOneAccessToken=${VERSIONONE_ACCESS_TOKEN:-accessToken}
+
+#Start dates from which to begin collector data, if no other data is present - usually, a month back is appropriate (required)
+feature.deltaStartDate=${VERSIONONE_DELTA_START_DATE:-2015-03-01T00:00:00.000000}
+feature.masterStartDate=${VERSIONONE_MASTER_START_DATE:-2008-01-01T00:00:00.000000}
+
+EOF
+
+echo "
+
+===========================================
+Properties file created `date`:  $PROP_FILE
+Note: passwords hidden
+===========================================
+`cat $PROP_FILE |egrep -vi password`
+ "
+
+exit 0

--- a/versionone-feature-collector/pom.xml
+++ b/versionone-feature-collector/pom.xml
@@ -40,6 +40,42 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+
+			<plugin>
+				<groupId>com.spotify</groupId>
+				<artifactId>docker-maven-plugin</artifactId>
+				<configuration>
+					<skipDockerBuild>false</skipDockerBuild>
+					<imageName>hygieia-versionone-collector</imageName>
+					<dockerDirectory>${project.basedir}/docker</dockerDirectory>
+					<resources>
+						<resource>
+							<targetPath>/</targetPath>
+							<directory>${project.build.directory}</directory>
+							<include>${project.build.finalName}.jar</include>
+						</resource>
+					</resources>
+				</configuration>
+			</plugin>
+
+		    <plugin>
+			<groupId>org.jacoco</groupId>
+			<artifactId>jacoco-maven-plugin</artifactId>
+			<executions>
+			    <execution>
+				<goals>
+				    <goal>prepare-agent</goal>
+				</goals>
+			    </execution>
+			    <execution>
+				<id>report</id>
+				<phase>verify</phase>
+				<goals>
+				    <goal>report</goal>
+				</goals>
+			    </execution>
+			</executions>
+		    </plugin>
 		</plugins>
 
 		<testResources>


### PR DESCRIPTION
Fixed the Sonar build and updated docker containers for all modules.

* #337 - Add Docker Containers for stash/svn/udeploy/versionone & cleanup docker file for jenkins test instance (5 days ago) Jim Zucker

* #363 - updated the jacoco plugin to the current version (8 days ago) Jim Zucker

* #364 Upgrade maven-compiler-plugin to 3.5.1 rev

*  #365 Jacoco not running for all subproject -  Fixed jacoco/Sonar runs.  There is one outstanding issue and sonar is skipped for the git and stash collectors(ref #370)  

*  #351 - PMD Warning - Overridable method called during object construction - had to fix them in this branch as build was failing after compiler upgrade (9 days ago) Jim Zucker

It is safe to commit but I need help testing these containers: 
jira
version-one
subversion
udeploy

if somebody can give me details what to setup I am happy to test and I can create esc environments for them like I did for Jenkins & Sonar.
![screenshot 2016-03-04 12 40 32](https://cloud.githubusercontent.com/assets/14372687/13539619/5929f2ba-e206-11e5-8bdb-82f25c4eabed.png)

![screenshot 2016-03-04 12 40 40](https://cloud.githubusercontent.com/assets/14372687/13539613/546805fa-e206-11e5-9e2b-fc7fdf42b073.png)
