### PR TITLE
reference #368 Code collector widget showing different tech debt value vs SONAR UI

### DIFF
--- a/UI/src/components/widgets/codeanalysis/view.js
+++ b/UI/src/components/widgets/codeanalysis/view.js
@@ -52,9 +52,9 @@
             ctrl.rulesCompliance = getMetric(caData.metrics, 'violations_density');
 
             ctrl.technicalDebt = getMetric(caData.metrics, 'sqale_index');
-	 
+
+		//the JSON contains the required info in ctrl.technicalDebt.formattedValue, no need to calculate	 
             //ctrl.technicalDebt.formattedValue = calculateTechnicalDebt(ctrl.technicalDebt.value);
-            ctrl.technicalDebt.formattedValue = ctrl.technicalDebt.formattedValue;
 
             ctrl.linesofCode = getMetric(caData.metrics, 'ncloc');
 


### PR DESCRIPTION
@jdamick I removed unnecessary code identified in code review

reference #368 Code collector widget showing different tech debt value

In the current code I found the math was wrong, but after further testing we found it better to simply use the formatted value returned in the JSON from SONAR, then we will always match.
