### PR TITLE
Fix for orphaned commits in commit stage of pipeline when no build configured

### DIFF
--- a/core/src/test/java/com/capitalone/dashboard/event/CommitEventListenerTest.java
+++ b/core/src/test/java/com/capitalone/dashboard/event/CommitEventListenerTest.java
@@ -1,0 +1,136 @@
+package com.capitalone.dashboard.event;
+
+import com.capitalone.dashboard.model.*;
+import com.capitalone.dashboard.repository.*;
+import org.bson.types.ObjectId;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CommitEventListenerTest {
+
+    @Mock
+    private ComponentRepository componentRepository;
+
+    @Mock
+    private DashboardRepository dashboardRepository;
+
+    @Mock
+    private CollectorRepository collectorRepository;
+
+    @Mock
+    private CollectorItemRepository collectorItemRepository;
+
+    @Mock
+    private PipelineRepository pipelineRepository;
+
+    @InjectMocks
+    private CommitEventListener eventListener;
+
+    private static final boolean HAS_BUILD_COLLECTOR = true;
+    private static final boolean NO_BUILD_COLLECTOR = false;
+
+    @Test
+    public void commitSaved_addedToPipeline() {
+        // Arrange
+        Commit commit = createCommit("myCommit");
+        Dashboard dashboard = createDashboard(HAS_BUILD_COLLECTOR);
+        Pipeline pipeline = new Pipeline();
+
+        setupFindDashboards(commit, dashboard);
+        setupGetOrCreatePipeline(dashboard, pipeline);
+
+        // Act
+        eventListener.onAfterSave(new AfterSaveEvent<>(commit, null, ""));
+
+        // Assert
+        boolean commitFound = pipeline.getStages()
+                .get(PipelineStageType.Commit.name())
+                .getCommits()
+                .stream()
+                .anyMatch(pc -> pc.getScmRevisionNumber().equals(commit.getScmRevisionNumber()));
+        assertThat(commitFound, is(true));
+        verify(pipelineRepository).save(pipeline);
+    }
+
+    @Test
+    public void commitSaved_noBuildCollector_notAddedToPipeline() {
+        // Arrange
+        Commit commit = createCommit("myCommit");
+        Dashboard dashboard = createDashboard(NO_BUILD_COLLECTOR);
+        Pipeline pipeline = new Pipeline();
+
+        setupFindDashboards(commit, dashboard);
+        setupGetOrCreatePipeline(dashboard, pipeline);
+
+        // Act
+        eventListener.onAfterSave(new AfterSaveEvent<>(commit, null, ""));
+
+        // Assert
+        assertThat(pipeline.getStages().get(PipelineStageType.Commit.name()), nullValue());
+        verify(pipelineRepository, never()).save(pipeline);
+    }
+
+    private Commit createCommit(String revisionNumber) {
+        Commit commit = new Commit();
+        commit.setScmRevisionNumber(revisionNumber);
+        commit.setCollectorItemId(ObjectId.get());
+        return commit;
+    }
+
+    private Dashboard createDashboard(boolean hasBuildCollector) {
+        Component component = new Component();
+        component.setId(ObjectId.get());
+        component.addCollectorItem(CollectorType.Product, collectorItem());
+        if (hasBuildCollector) {
+            component.addCollectorItem(CollectorType.Build, collectorItem());
+        }
+
+        Application application = new Application("app", component);
+        Dashboard dashboard = new Dashboard("template", "title", application, "owner", DashboardType.Team);
+        dashboard.setId(ObjectId.get());
+        return dashboard;
+    }
+
+    private void setupFindDashboards(Commit commit, Dashboard dashboard) {
+        CollectorItem commitCollectorItem = new CollectorItem();
+        List<Component> components = Collections.singletonList(dashboard.getApplication().getComponents().get(0));
+        commitCollectorItem.setId(commit.getCollectorItemId());
+        when(collectorItemRepository.findOne(commit.getCollectorItemId())).thenReturn(commitCollectorItem);
+        when(componentRepository.findBySCMCollectorItemId(commitCollectorItem.getId())).thenReturn(components);
+        when(dashboardRepository.findByApplicationComponentsIn(components)).thenReturn(Collections.singletonList(dashboard));
+    }
+
+    private void setupGetOrCreatePipeline(Dashboard dashboard, Pipeline pipeline) {
+        Collector productCollector = new Collector();
+        productCollector.setId(ObjectId.get());
+        CollectorItem teamDashboardCI = collectorItem();
+
+        when(collectorRepository.findByCollectorType(CollectorType.Product))
+                .thenReturn(Collections.singletonList(productCollector));
+        when(collectorItemRepository.findTeamDashboardCollectorItemsByCollectorIdAndDashboardId(productCollector.getId(), dashboard.getId().toString()))
+                .thenReturn(teamDashboardCI);
+        when(pipelineRepository.findByCollectorItemId(teamDashboardCI.getId())).thenReturn(pipeline);
+    }
+
+    private CollectorItem collectorItem() {
+        CollectorItem item = new CollectorItem();
+        item.setId(ObjectId.get());
+        return item;
+    }
+
+}


### PR DESCRIPTION
This PR is to fix a bug whereby commits can be orphaned in the commit stage of the product pipeline widget.

Here is the scenario:

1. A (team) dashboard exists with a configured SCM widget (using the Github webhook push method)
2. The same dashboard does **NOT** have a build widget configured
3. A new commit (call it commit A) is pushed to the Github repo
4. The build widget is then added to the team dashboard
5. A new product dashboard is created that references the team dashboard.
6. Commit A is displayed in the commit stage and never moves to subsequent stages.

This PR proposes to fix the bug by not adding commits to the pipeline of a team dashboard if there is no build widget configured.
