### PR TITLE
Fix mongoDB database name references as dashboard in all modules.

### DIFF
--- a/Setup.md
+++ b/Setup.md
@@ -24,14 +24,14 @@ The following components are required to run Hygieia℠:
          MongoDB shell version: 3.0.4
          connecting to: test  
 
-         > use dashboarddb
-         switched to db dashboarddb
+         > use dashboard
+         switched to db dashboard
          > db.createUser(
                   {
-                    user: "dbuser",
+                    user: "db",
                     pwd: "dbpass",
                     roles: [
-                       {role: "readWrite", db: "dashboarddb"}
+                       {role: "readWrite", db: "dashboard"}
                             ]
                     })
                 Successfully added user: {
@@ -39,7 +39,7 @@ The following components are required to run Hygieia℠:
                   "roles" : [
                   {
                     "role" : "readWrite",
-                    "db" : "dashboarddb"
+                    "db" : "dashboard"
                   }
                   ]
                 }  
@@ -47,7 +47,7 @@ The following components are required to run Hygieia℠:
 
 
 We recommend that you download  MongoDB clients(RoboMongo etc) to connect to your local
-running Database and make sure that dashboarddb is created and you are successfully able to connect to it.
+running Database and make sure that database: dashboard is created and you are successfully able to connect to it.
 
 #### API Layer
 Please click on the link below to learn about how to build and run the API layer

--- a/Setup.md
+++ b/Setup.md
@@ -24,22 +24,22 @@ The following components are required to run Hygieia℠:
          MongoDB shell version: 3.0.4
          connecting to: test  
 
-         > use dashboardb
-         switched to db dashboardb
+         > use dashboarddb
+         switched to db dashboarddb
          > db.createUser(
                   {
-                    user: "db",
+                    user: "dbuser",
                     pwd: "dbpass",
                     roles: [
-                       {role: "readWrite", db: "dashboard"}
+                       {role: "readWrite", db: "dashboarddb"}
                             ]
                     })
                 Successfully added user: {
-                  "user" : "db",
+                  "user" : "dbuser",
                   "roles" : [
                   {
                     "role" : "readWrite",
-                    "db" : "dashboard"
+                    "db" : "dashboarddb"
                   }
                   ]
                 }  

--- a/github-scm-collector/README.md
+++ b/github-scm-collector/README.md
@@ -24,7 +24,7 @@ for information about sourcing this properties file.
 ###Sample application.properties file
 --------------------------------------
     #Database Name 
-    database=dashboarddb
+    database=dashboard
 
     #Database HostName - default is localhost
     dbhost=10.0.1.1

--- a/jenkins-build-collector/README.md
+++ b/jenkins-build-collector/README.md
@@ -23,7 +23,7 @@ for information about sourcing this properties file.
 --------------------------------------
 
     #Database Name 
-    dbname=dashboarddb
+    dbname=dashboard
 
     #Database HostName - default is localhost
     dbhost=localhost

--- a/jira-feature-collector/README.md
+++ b/jira-feature-collector/README.md
@@ -23,7 +23,7 @@ for information about sourcing this properties file.
 --------------------------------------
 
     #Database Name - default is test
-    spring.data.mongodb.database=dashboarddb
+    spring.data.mongodb.database=dashboard
 
     #Database HostName - default is localhost
     spring.data.mongodb.host=10.0.1.1

--- a/subversion-scm-collector/README.md
+++ b/subversion-scm-collector/README.md
@@ -23,7 +23,7 @@ for information about sourcing this properties file.
 --------------------------------------
 
     #Database Name 
-    spring.data.mongodb.database=dashboarddb
+    spring.data.mongodb.database=dashboard
 
     #Database HostName - default is localhost
     spring.data.mongodb.host=10.0.1.1

--- a/udeploy-deployment-collector/README.md
+++ b/udeploy-deployment-collector/README.md
@@ -23,7 +23,7 @@ for information about sourcing this properties file.
 --------------------------------------
 
     #Database Name
-    spring.data.mongodb.database=dashboarddb
+    spring.data.mongodb.database=dashboard
 
     #Database HostName - default is localhost
     spring.data.mongodb.host=10.0.1.1

--- a/versionone-feature-collector/README.md
+++ b/versionone-feature-collector/README.md
@@ -23,7 +23,7 @@ for information about sourcing this properties file.
 --------------------------------------
 
     #Database Name 
-    spring.data.mongodb.database=dashboarddb
+    spring.data.mongodb.database=dashboard
 
     #Database HostName - default is localhost
     spring.data.mongodb.host=10.0.1.1


### PR DESCRIPTION
Hi
Please pull my changes are documentation for setting mongoDB database name is mentioned "dashboard" and "dashboard**db**" or "dashboard**b**" in different places (aka main or module level README.MD files). I fixed those so that other people won't face much issues.

Thanks.
Arun Sangal