### PR TITLE
Add basic auth support to sonarqube collector

### DIFF
--- a/sonar-codequality-collector/docker/sonar-codequality-properties-builder.sh
+++ b/sonar-codequality-collector/docker/sonar-codequality-properties-builder.sh
@@ -7,10 +7,10 @@ if [ "$TEST_SCRIPT" != "" ]
 then
         #for testing locally
         PROP_FILE=application.properties
-else 
+else
 	PROP_FILE=hygieia-sonar-codequality-collector.properties
 fi
-  
+
 if [ "$MONGO_PORT" != "" ]; then
 	# Sample: MONGO_PORT=tcp://172.17.0.20:27017
 	MONGODB_HOST=`echo $MONGO_PORT|sed 's;.*://\([^:]*\):\(.*\);\1;'`
@@ -58,6 +58,12 @@ dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
 sonar.cron=${SONAR_CRON:-0 0/5 * * * *}
 
 sonar.servers[0]=${SONAR_URL:-http://localhost:9000}
+
+#Sonar Authentication Username - default is blank
+sonar.username=${SONAR_USERNAME:-sonarusername}
+
+#Sonar Authentication Password - default is blank
+sonar.password=${SONAR_PASSWORD:-sonarpassword}
 
 #Sonar Metrics
 sonar.metrics=${SONAR_METRICS:-ncloc,line_coverage,violations,critical_violations,major_violations,blocker_violations,sqale_index,test_success_density,test_failures,test_errors,tests}

--- a/sonar-codequality-collector/src/main/java/com/capitalone/dashboard/collector/SonarSettings.java
+++ b/sonar-codequality-collector/src/main/java/com/capitalone/dashboard/collector/SonarSettings.java
@@ -12,6 +12,8 @@ import java.util.List;
 @ConfigurationProperties(prefix = "sonar")
 public class SonarSettings {
     private String cron;
+    private String username;
+    private String password;
     private String metrics;
     private List<String> servers;
 
@@ -21,6 +23,22 @@ public class SonarSettings {
 
     public void setCron(String cron) {
         this.cron = cron;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
     }
 
     public String getMetrics() {


### PR DESCRIPTION
This PR adds HTTP basic authentication support to the SonarQube collector.