### PR TITLE
#638 - upgrade docker plugin to fix issue using it with docker mac 1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
 				<plugin>
 					<groupId>com.spotify</groupId>
 					<artifactId>docker-maven-plugin</artifactId>
-					<version>0.4.0</version>
+					<version>0.4.10</version>
 				</plugin>
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Upgraded docker plugin to 0.4.10 to work with Docker Mac