### PR TITLE
Update image src to use path relative to current page

### DIFF
--- a/chatops_collector.html
+++ b/chatops_collector.html
@@ -41,11 +41,11 @@ slug: chatops_collector
 
   <h3 id="widget">Widget</h3>
 
-  <img class="img-responsive" style="height:50%;" src="/images/chatops.png">
+  <img class="img-responsive" style="height:50%;" src="images/chatops.png">
 
   <h3 id="chat_ops_configure_screen">ChatOps Configure Screen</h3>
 
-  <img src="/images/chatopsconfig.png" class="img-responsive" style="height:50%;width:50%">
+  <img src="images/chatopsconfig.png" class="img-responsive" style="height:50%;width:50%">
 
 </div>
 

--- a/plugin_webhook.html
+++ b/plugin_webhook.html
@@ -40,10 +40,10 @@ Run unit tests
 <li>Configure Global Hygieia Publisher in Jenkins Manage Jenkins/Configure System. Enter Hygieia API url such as http://localhost:8090/api. There is no API token implented at this time and it is work in progress.</li>
 </ul>
 
-<img src="/images/jenkins-global.png" class="img-responsive">
+<img src="images/jenkins-global.png" class="img-responsive">
 <ul>
   <li>For a build job, add a Post build action "Hygieia Publisher".</li>
 <li>Select what to send to Hygieia. Currently, "Build", "Artifact Info", "Sonar Anslysis", "Deployment" and "Cucumber Test Results" can be published.</li>
 </ul>
-<img src="/images/jenkins-job-config.png" class="img-responsive">
+<img src="images/jenkins-job-config.png" class="img-responsive">
 </div>

--- a/ui.html
+++ b/ui.html
@@ -131,11 +131,11 @@ slug: ui
       <img src="images/apiup.png" style="width:50%;">
 
       <h3>API layer successfully connected</h3>
-      <img src="/images/apiup.png" style="width:50%;">
+      <img src="images/apiup.png" style="width:50%;">
 
       <h3>API layer connection unsuccessful</h3>
-      <img src="/images/apidown.png" style="width:50%;">
+      <img src="images/apidown.png" style="width:50%;">
 
       <h3>ScreenShot of login page with API Layer up</h3>
-      <img src="/images/loginpage.png" style="width:50%;">
+      <img src="images/loginpage.png" style="width:50%;">
     </div>


### PR DESCRIPTION
Some of the images in the documentation do not appear because
the img src references the root context, which happens when the
documentation website is hosted on GitHub due to the project
prefix ("Hygieia").

This removes the root prefix ("/") for the affected images.