### PR TITLE
Fix log output bug - possible missing spaces between tokens

### DIFF
--- a/core/src/main/java/com/capitalone/dashboard/collector/CollectorTask.java
+++ b/core/src/main/java/com/capitalone/dashboard/collector/CollectorTask.java
@@ -106,10 +106,10 @@ public abstract class CollectorTask<T extends Collector> implements Runnable {
         String token2 = "";
         String token3;
         if (count == null) {
-            token3 = Strings.padStart(elapsed, 35 - text.length(), ' ');
+            token3 = Strings.padStart(" " + elapsed, 35 - text.length(), ' ');
         } else {
-            token2 = Strings.padStart(count.toString(), 25 - text.length(), ' ');
-            token3 = Strings.padStart(elapsed, 10, ' ');
+            token2 = Strings.padStart(" " + count.toString(), 25 - text.length(), ' ');
+            token3 = Strings.padStart(" " + elapsed, 10, ' ');
         }
         LOGGER.info(text + token2 + token3);
     }


### PR DESCRIPTION
Hi,
While trying to run the Jenkins build collector I've found that a place without proper spacing in the logs.

Example:
`2016-09-03 04:22:00,302 INFO  c.c.d.collector.CollectorTask - Error getting jobs for: http://10.100.68.2380s`

Note that the '0s' is not separated from the host at the end.
My change should make it so that there is always at least one space between the tokens.