### PR TITLE
Fix property generator scripts to generate 'dbname' property instead of 'database'

### DIFF
--- a/Bamboo-build-collector/docker/bamboo-build-properties-builder.sh
+++ b/Bamboo-build-collector/docker/bamboo-build-properties-builder.sh
@@ -53,7 +53,7 @@ fi
 
 cat > $PROP_FILE <<EOF
 #Database Name
-database=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/bitbucket-scm-collector/README.md
+++ b/bitbucket-scm-collector/README.md
@@ -25,7 +25,7 @@ for information about sourcing this properties file.
 --------------------------------------
 
     #Database Name 
-    spring.data.mongodb.database=dashboarddb
+    spring.data.mongodb.dbname=dashboarddb
 
     #Database HostName - default is localhost
     spring.data.mongodb.host=

--- a/bitbucket-scm-collector/docker/bitbucket-properties-builder.sh
+++ b/bitbucket-scm-collector/docker/bitbucket-properties-builder.sh
@@ -27,7 +27,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name
-database=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/chat-ops-collector/docker/chat-ops-properties-builder.sh
+++ b/chat-ops-collector/docker/chat-ops-properties-builder.sh
@@ -27,7 +27,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name
-database=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/github-scm-collector/README.md
+++ b/github-scm-collector/README.md
@@ -24,7 +24,7 @@ for information about sourcing this properties file.
 ###Sample application.properties file
 --------------------------------------
     #Database Name 
-    database=dashboard
+    dbname=dashboard
 
     #Database HostName - default is localhost
     dbhost=10.0.1.1

--- a/github-scm-collector/docker/github-properties-builder.sh
+++ b/github-scm-collector/docker/github-properties-builder.sh
@@ -27,7 +27,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name
-database=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/jenkins-build-collector/docker/jenkins-build-properties-builder.sh
+++ b/jenkins-build-collector/docker/jenkins-build-properties-builder.sh
@@ -53,7 +53,7 @@ fi
 
 cat > $PROP_FILE <<EOF
 #Database Name
-database=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/jenkins-cucumber-test-collector/docker/jenkins-cucumber-test-properties-builder.sh
+++ b/jenkins-cucumber-test-collector/docker/jenkins-cucumber-test-properties-builder.sh
@@ -41,7 +41,7 @@ fi
 
 cat > $PROP_FILE <<EOF
 #Database Name
-database=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/jira-feature-collector/docker/jira-properties-builder.sh
+++ b/jira-feature-collector/docker/jira-properties-builder.sh
@@ -26,7 +26,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name
-database=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/sonar-codequality-collector/README.md
+++ b/sonar-codequality-collector/README.md
@@ -23,7 +23,7 @@ for information about sourcing this properties file.
 --------------------------------------
 
     #Database Name
-    database=dashboard
+    dbname=dashboard
 
     #Database HostName - default is localhost
     dbhost=10.0.1.1

--- a/sonar-codequality-collector/docker/sonar-codequality-properties-builder.sh
+++ b/sonar-codequality-collector/docker/sonar-codequality-properties-builder.sh
@@ -40,7 +40,7 @@ fi
 
 cat > $PROP_FILE <<EOF
 #Database Name
-database=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/subversion-scm-collector/README.md
+++ b/subversion-scm-collector/README.md
@@ -23,7 +23,7 @@ for information about sourcing this properties file.
 --------------------------------------
 
     #Database Name 
-    spring.data.mongodb.database=dashboard
+    spring.data.mongodb.dbname=dashboard
 
     #Database HostName - default is localhost
     spring.data.mongodb.host=10.0.1.1

--- a/subversion-scm-collector/docker/subversion-properties-builder.sh
+++ b/subversion-scm-collector/docker/subversion-properties-builder.sh
@@ -27,7 +27,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name
-database=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/udeploy-deployment-collector/README.md
+++ b/udeploy-deployment-collector/README.md
@@ -23,7 +23,7 @@ for information about sourcing this properties file.
 --------------------------------------
 
     #Database Name
-    spring.data.mongodb.database=dashboard
+    spring.data.mongodb.dbname=dashboard
 
     #Database HostName - default is localhost
     spring.data.mongodb.host=10.0.1.1

--- a/udeploy-deployment-collector/docker/udeploy-properties-builder.sh
+++ b/udeploy-deployment-collector/docker/udeploy-properties-builder.sh
@@ -27,7 +27,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name
-database=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/versionone-feature-collector/docker/versionone-properties-builder.sh
+++ b/versionone-feature-collector/docker/versionone-properties-builder.sh
@@ -27,7 +27,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name
-database=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/xldeploy-deployment-collector/README.md
+++ b/xldeploy-deployment-collector/README.md
@@ -23,7 +23,7 @@ for information about sourcing this properties file.
 --------------------------------------
 
 	#Database Name
-	database=dashboard
+	dbname=dashboard
 	
 	#Database HostName - default is localhost
 	dbhost=192.168.33.11

--- a/xldeploy-deployment-collector/docker/xldeploy-properties-builder.sh
+++ b/xldeploy-deployment-collector/docker/xldeploy-properties-builder.sh
@@ -27,7 +27,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name
-database=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}


### PR DESCRIPTION
Almost all of the property generator scripts use a property named 'database' to specify what database to use. The code uses 'dbname'. Someone probably changed this property a while ago and forgot to update the property generator scripts. It has gone unnoticed because people probably have just used the default value for the database name.

This change fixes the property generator and property files to properly use 'dbname'