### PR TITLE
Add scm parent revision numbers to Commits

### DIFF
--- a/api/src/main/java/com/capitalone/dashboard/model/PipelineResponseCommit.java
+++ b/api/src/main/java/com/capitalone/dashboard/model/PipelineResponseCommit.java
@@ -6,14 +6,7 @@ import java.util.Map;
 public class PipelineResponseCommit extends SCM {
 
     public PipelineResponseCommit(SCM scm) {
-        this.scmCommitLog = scm.scmCommitLog;
-        this.scmUrl = scm.scmUrl;
-        this.scmBranch = scm.scmBranch;
-        this.scmRevisionNumber = scm.scmRevisionNumber;
-        this.scmCommitLog = scm.scmCommitLog;
-        this.scmAuthor = scm.scmAuthor;
-        this.scmCommitTimestamp = scm.scmCommitTimestamp;
-        this.numberOfChanges = scm.numberOfChanges;
+    	super(scm);
     }
 
     Map<String, Long> processedTimestamps = new HashMap<>();

--- a/api/src/main/java/com/capitalone/dashboard/service/CommitServiceImpl.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/CommitServiceImpl.java
@@ -190,10 +190,20 @@ public class CommitServiceImpl implements CommitService {
                 int numberChanges = ((JSONArray) cObj.get("added")).size() +
                         ((JSONArray) cObj.get("removed")).size() +
                         ((JSONArray) cObj.get("modified")).size();
+                
+                JSONArray parents = (JSONArray) jsonObject.get("parents");
+				List<String> parentShas = new ArrayList<>();
+				if (parents != null) {
+					for (Object parentObj : parents) {
+						parentShas.add(str((JSONObject)parentObj, "sha"));
+					}
+				}
+                
                 Commit commit = new Commit();
                 commit.setScmUrl(url);
                 commit.setTimestamp(System.currentTimeMillis()); // this is hygieia timestamp.
                 commit.setScmRevisionNumber(str(cObj, "id"));
+                commit.setScmParentRevisionNumbers(parentShas);
                 commit.setScmAuthor(author);
                 commit.setScmCommitLog(message);
                 commit.setScmCommitTimestamp(timestamp); // actual search timestamp

--- a/collectors/scm/bitbucket/src/main/java/com/capitalone/dashboard/collector/DefaultBitbucketCloudClient.java
+++ b/collectors/scm/bitbucket/src/main/java/com/capitalone/dashboard/collector/DefaultBitbucketCloudClient.java
@@ -147,11 +147,19 @@ public class DefaultBitbucketCloudClient implements GitClient {
 					String message = str(jsonObject, "message");
 					String author = str(authorObject, "raw");
 					long timestamp = new DateTime(str(jsonObject, "date")).getMillis();
+					JSONArray parents = (JSONArray) jsonObject.get("parents");
+					List<String> parentShas = new ArrayList<>();
+					if (parents != null) {
+						for (Object parentObj : parents) {
+							parentShas.add(str((JSONObject)parentObj, "id"));
+						}
+					}
 					
 					Commit commit = new Commit();
 					commit.setTimestamp(System.currentTimeMillis());
 					commit.setScmUrl(repo.getRepoUrl());
 					commit.setScmRevisionNumber(sha);
+					commit.setScmParentRevisionNumbers(parentShas);
 					commit.setScmAuthor(author);
 					commit.setScmCommitLog(message);
 					commit.setScmCommitTimestamp(timestamp);

--- a/collectors/scm/bitbucket/src/main/java/com/capitalone/dashboard/collector/DefaultBitbucketServerClient.java
+++ b/collectors/scm/bitbucket/src/main/java/com/capitalone/dashboard/collector/DefaultBitbucketServerClient.java
@@ -96,11 +96,19 @@ public class DefaultBitbucketServerClient implements GitClient {
 					String message = str(jsonObject, "message");
 					String author = str(authorObject, "name");
 					long timestamp = Long.valueOf(str(jsonObject,"authorTimestamp"));
+					JSONArray parents = (JSONArray) jsonObject.get("parents");
+					List<String> parentShas = new ArrayList<>();
+					if (parents != null) {
+						for (Object parentObj : parents) {
+							parentShas.add(str((JSONObject)parentObj, "id"));
+						}
+					}
 					
 					Commit commit = new Commit();
 					commit.setTimestamp(System.currentTimeMillis());
 					commit.setScmUrl(repo.getRepoUrl());
 					commit.setScmRevisionNumber(sha);
+					commit.setScmParentRevisionNumbers(parentShas);
 					commit.setScmAuthor(author);
 					commit.setScmCommitLog(message);
 					commit.setScmCommitTimestamp(timestamp);

--- a/collectors/scm/bitbucket/src/test/java/com/capitalone/dashboard/collector/DefaultBitbucketServerClientTest.java
+++ b/collectors/scm/bitbucket/src/test/java/com/capitalone/dashboard/collector/DefaultBitbucketServerClientTest.java
@@ -85,6 +85,9 @@ public class DefaultBitbucketServerClientTest {
         assertEquals("215e5a6cbbda3a0cf4271a7e7c799306d3adb9ad", commits.get(0).getScmRevisionNumber());
         assertEquals("billybob", commits.get(0).getScmAuthor());
         assertEquals("Message 1", commits.get(0).getScmCommitLog());
+        assertEquals(2, commits.get(0).getScmParentRevisionNumbers().size());
+        assertEquals("9097aee6916a1883945b9cf9b77d351dc6802307", commits.get(0).getScmParentRevisionNumbers().get(0));
+        assertEquals("30a9559513e471fb8f1deff10bd8823ad74a2fab", commits.get(0).getScmParentRevisionNumbers().get(1));
         assertEquals(1463771960000L, commits.get(0).getScmCommitTimestamp());
         
         assertTrue(0 != commits.get(1).getTimestamp());
@@ -92,6 +95,8 @@ public class DefaultBitbucketServerClientTest {
         assertEquals("30a9559513e471fb8f1deff10bd8823ad74a2fab", commits.get(1).getScmRevisionNumber());
         assertEquals("billybob", commits.get(1).getScmAuthor());
         assertEquals("Message 2", commits.get(1).getScmCommitLog());
+        assertEquals(1, commits.get(1).getScmParentRevisionNumbers().size());
+        assertEquals("9097aee6916a1883945b9cf9b77d351dc6802307", commits.get(1).getScmParentRevisionNumbers().get(0));
         assertEquals(1463771869000L, commits.get(1).getScmCommitTimestamp());
     }
     

--- a/collectors/scm/github/src/main/java/com/capitalone/dashboard/collector/DefaultGitHubClient.java
+++ b/collectors/scm/github/src/main/java/com/capitalone/dashboard/collector/DefaultGitHubClient.java
@@ -140,11 +140,19 @@ public class DefaultGitHubClient implements GitHubClient {
 					long timestamp = new DateTime(str(authorObject, "date"))
 							.getMillis();
                     JSONArray parents = (JSONArray) jsonObject.get("parents");
+					List<String> parentShas = new ArrayList<>();
+					if (parents != null) {
+						for (Object parentObj : parents) {
+							parentShas.add(str((JSONObject)parentObj, "sha"));
+						}
+					}
+                    
 					Commit commit = new Commit();
 					commit.setTimestamp(System.currentTimeMillis());
 					commit.setScmUrl(repo.getRepoUrl());
                     commit.setScmBranch(repo.getBranch());
 					commit.setScmRevisionNumber(sha);
+					commit.setScmParentRevisionNumbers(parentShas);
 					commit.setScmAuthor(author);
 					commit.setScmCommitLog(message);
 					commit.setScmCommitTimestamp(timestamp);

--- a/collectors/scm/github/src/test/java/com/capitalone/dashboard/collector/GitHubCollectorTaskTest.java
+++ b/collectors/scm/github/src/test/java/com/capitalone/dashboard/collector/GitHubCollectorTaskTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -86,6 +87,7 @@ public class GitHubCollectorTaskTest {
         commit.setScmUrl("http://testcurrenturl");
         commit.setScmBranch("master");
         commit.setScmRevisionNumber("1");
+        commit.setScmParentRevisionNumbers(Collections.singletonList("2"));
         commit.setScmAuthor("author");
         commit.setScmCommitLog("This is a test commit");
         commit.setScmCommitTimestamp(System.currentTimeMillis());

--- a/core/src/main/java/com/capitalone/dashboard/event/CommitEventListener.java
+++ b/core/src/main/java/com/capitalone/dashboard/event/CommitEventListener.java
@@ -37,7 +37,7 @@ public class CommitEventListener extends HygieiaMongoEventListener<Commit> {
                 .stream()
                 .filter(this::dashboardHasBuildCollector)
                 .forEach(teamDashboard -> {
-                    if (commit.getType().equals(CommitType.New)) {
+                    if (CommitType.New.equals(commit.getType())) {
                         PipelineCommit pipelineCommit = new PipelineCommit(commit, commit.getScmCommitTimestamp());
                         Pipeline pipeline = getOrCreatePipeline(teamDashboard);
                         pipeline.addCommit(PipelineStageType.Commit.name(), pipelineCommit);

--- a/core/src/main/java/com/capitalone/dashboard/model/PipelineCommit.java
+++ b/core/src/main/java/com/capitalone/dashboard/model/PipelineCommit.java
@@ -9,13 +9,8 @@ public class PipelineCommit extends SCM{
         this.timestamp = timestamp;
     }
 
-    public PipelineCommit(String scmUrl, String scmBranch, String scmRevisionNumber, String scmCommitLog, String scmAuthor, long scmCommitTimestamp, long numberOfChanges, long timestamp) {
-        super(scmUrl, scmBranch, scmRevisionNumber, scmCommitLog, scmAuthor, scmCommitTimestamp, numberOfChanges);
-        this.timestamp = timestamp;
-    }
-
     public PipelineCommit(SCM scm, long timestamp){
-        super(scm.scmUrl, scm.scmBranch, scm.scmRevisionNumber, scm.scmCommitLog, scm.scmAuthor, scm.scmCommitTimestamp, scm.numberOfChanges);
+        super(scm);
         this.timestamp = timestamp;
     }
     private long timestamp;

--- a/core/src/main/java/com/capitalone/dashboard/model/SCM.java
+++ b/core/src/main/java/com/capitalone/dashboard/model/SCM.java
@@ -1,5 +1,7 @@
 package com.capitalone.dashboard.model;
 
+import java.util.List;
+
 /**
  * Base class to represent the details of a change in a source code management
  * system.
@@ -10,6 +12,7 @@ public class SCM {
 	protected String scmRevisionNumber;
     protected String scmCommitLog;
     protected String scmAuthor;
+    protected List<String> scmParentRevisionNumbers;
     protected long scmCommitTimestamp;
     protected long numberOfChanges;
     protected CommitType type;
@@ -17,24 +20,26 @@ public class SCM {
     public SCM(){
 
     }
-
-    public SCM(String scmUrl, String scmBranch, String scmRevisionNumber, String scmCommitLog, String scmAuthor, long scmCommitTimestamp, long numberOfChanges) {
-        this.scmUrl = scmUrl;
-        this.scmBranch = scmBranch;
-        this.scmRevisionNumber = scmRevisionNumber;
-        this.scmCommitLog = scmCommitLog;
-        this.scmAuthor = scmAuthor;
-        this.scmCommitTimestamp = scmCommitTimestamp;
-        this.numberOfChanges = numberOfChanges;
-        this.type = CommitType.New;
+    
+    public SCM(SCM scm) {
+        this.scmUrl = scm.scmUrl;
+        this.scmBranch = scm.scmBranch;
+        this.scmRevisionNumber = scm.scmRevisionNumber;
+        this.scmCommitLog = scm.scmCommitLog;
+        this.scmAuthor = scm.scmAuthor;
+        this.scmParentRevisionNumbers = scm.scmParentRevisionNumbers;
+        this.scmCommitTimestamp = scm.scmCommitTimestamp;
+        this.numberOfChanges = scm.numberOfChanges;
+        this.type = scm.type;
     }
 
-    public SCM(String scmUrl, String scmBranch, String scmRevisionNumber, String scmCommitLog, String scmAuthor, long scmCommitTimestamp, long numberOfChanges, CommitType type) {
+    public SCM(String scmUrl, String scmBranch, String scmRevisionNumber, String scmCommitLog, String scmAuthor, List<String> scmParentRevisionNumbers, long scmCommitTimestamp, long numberOfChanges, CommitType type) {
         this.scmUrl = scmUrl;
         this.scmBranch = scmBranch;
         this.scmRevisionNumber = scmRevisionNumber;
         this.scmCommitLog = scmCommitLog;
         this.scmAuthor = scmAuthor;
+        this.scmParentRevisionNumbers = scmParentRevisionNumbers;
         this.scmCommitTimestamp = scmCommitTimestamp;
         this.numberOfChanges = numberOfChanges;
         this.type = type;
@@ -78,6 +83,15 @@ public class SCM {
 
     public void setScmAuthor(String scmAuthor) {
         this.scmAuthor = scmAuthor;
+    }
+    
+    // can return null
+    public List<String> getScmParentRevisionNumbers() {
+    	return scmParentRevisionNumbers;
+    }
+    
+    public void setScmParentRevisionNumbers(List<String> scmParentRevisionNumbers) {
+    	this.scmParentRevisionNumbers = scmParentRevisionNumbers;
     }
 
     public long getScmCommitTimestamp() {


### PR DESCRIPTION
Just as the title says. It will prove to be useful information in the future for some things I have planned. I wanted to get it in now so collectors can start filling up with the data.

Note that the parent revision data will only come from the commit collectors. SCM objects created by build collectors will not have the parent revision information (as it doesn't seem to be available in the api). Hence at present commits in the pipeline document for build and environments will not contain the parent scm revision number information.