### PR TITLE
Add gulp-order to enforce index.html js import order

### DIFF
--- a/UI/gulpfile.js
+++ b/UI/gulpfile.js
@@ -16,6 +16,7 @@ var browserSync = require('browser-sync'),
     less = require('gulp-less'),
     minifyHtml = require('gulp-htmlmin'),
     minifyCss = require('gulp-clean-css'),
+    order = require('gulp-order'),
     rename = require('gulp-rename'),
     replace = require('gulp-replace'),
     httpProxy = require('http-proxy'),
@@ -261,7 +262,10 @@ gulp.task('html', function() {
         .pipe(gulp.dest(hygieia.dist))
 
         // replace inject:js with script references to all the files in the following sources
-        .pipe(inject(gulp.src(!!argv.prod ? ['src/app/app.js'] : jsFiles), { name: 'hygieia', ignorePath: 'src', addRootSlash: false }))
+        .pipe(inject(gulp.src(
+    		!!argv.prod ? ['src/app/app.js'] : jsFiles)
+    		.pipe(order(['app/app.js', 'app/dashboard/core/module.js', 'app/**/*.js', 'components/**/*.js'])), 
+    		{ name: 'hygieia', ignorePath: 'src', addRootSlash: false }))
 
         // replace custom placeholders with our configured values
         .pipe(replace('[config]', JSON.stringify(config)))

--- a/UI/package.json
+++ b/UI/package.json
@@ -36,6 +36,7 @@
     "gulp-clean-css": "~2.0.10",
     "gulp-ng-annotate": "~0.5.2",
     "gulp-protractor": "~0.0.11",
+    "gulp-order": "~1.1.1",
     "gulp-rename": "~1.2.0",
     "gulp-replace": "~0.5.0",
     "gulp-rev": "~2.0.1",


### PR DESCRIPTION
Fix for #599

Currently the ordering of the hygieia:js files in index.html is non deterministic. It seems to change on me when file timestamps change. This PR will force <script src="app/dashboard/core/module.js"></script> to be at the top.