### PR TITLE
Added template for standalone cloud widget

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2,4 +2,3 @@ amitmawkin
 tabladrum
 mrpudn
 satishc1
-jdamick

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,5 @@
 amitmawkin
-jdamick
 tabladrum
+mrpudn
+satishc1
+jdamick

--- a/UI/src/app/dashboard/controllers/createDashboard.js
+++ b/UI/src/app/dashboard/controllers/createDashboard.js
@@ -23,6 +23,7 @@
         ctrl.templates = [
             {value: 'capone', name: 'Cap One', type: DashboardType.TEAM},
             {value: 'caponechatops', name: 'Cap One ChatOps', type: DashboardType.TEAM},
+            {value: 'cloud', name: 'Cloud Dashboard', type: DashboardType.TEAM},
             {value: 'splitview', name: 'Split View', type: DashboardType.TEAM},
             {value: 'product-dashboard', name: 'Product Dashboard', type: DashboardType.PRODUCT}
         ];

--- a/UI/src/components/templates/capone.html
+++ b/UI/src/components/templates/capone.html
@@ -7,9 +7,7 @@
 
                 {{::ctrl.dashboard.title}}
 
-                <div class="pipeline-toggle btn-group"
-
-                     ng-show="template.hasComponents(ctrl.dashboard, ['SCM'])">
+                <div class="pipeline-toggle btn-group">
 
                     <span class="btn" ng-repeat="tab in template.tabs" ng-click="template.toggleView($index)"
                           ng-class="tab.name == template.widgetView ? 'btn-primary' : 'btn-default'">

--- a/UI/src/components/templates/capone.js
+++ b/UI/src/components/templates/capone.js
@@ -23,21 +23,5 @@
         ctrl.toggleView = function (index) {
             ctrl.widgetView = typeof ctrl.tabs[index] === 'undefined' ? ctrl.tabs[0].name : ctrl.tabs[index].name;
         };
-
-        ctrl.hasComponents = function (dashboard, names) {
-            var hasAllComponents = true;
-
-            try {
-                _(names).forEach(function (name) {
-                    if(!dashboard.application.components[0].collectorItems[name]) {
-                        hasAllComponents = false;
-                    }
-                });
-            } catch(e) {
-                hasAllComponents = false;
-            }
-
-            return hasAllComponents;
-        };
     }
 })();

--- a/UI/src/components/templates/caponechatops.html
+++ b/UI/src/components/templates/caponechatops.html
@@ -7,9 +7,7 @@
 
                 {{::ctrl.dashboard.title}}
 
-                <div class="pipeline-toggle btn-group"
-
-                     ng-show="template.hasComponents(ctrl.dashboard, ['Deployment'])">
+                <div class="pipeline-toggle btn-group">
 
                     <span class="btn" ng-repeat="tab in template.tabs" ng-click="template.toggleView($index)"
                           ng-class="tab.name == template.widgetView ? 'btn-primary' : 'btn-default'">

--- a/UI/src/components/templates/cloud.html
+++ b/UI/src/components/templates/cloud.html
@@ -7,9 +7,7 @@
 
                 {{::ctrl.dashboard.title}}
 
-                <div class="pipeline-toggle btn-group"
-
-                     ng-show="template.hasComponents(ctrl.dashboard)">
+                <div class="pipeline-toggle btn-group">
 
                     <span class="btn" ng-repeat="tab in template.tabs" ng-click="template.toggleView($index)"
                           ng-class="tab.name == template.widgetView ? 'btn-primary' : 'btn-default'">

--- a/UI/src/components/templates/cloud.html
+++ b/UI/src/components/templates/cloud.html
@@ -1,4 +1,4 @@
-<div ng-controller="CapOneTemplateController as template">
+<div ng-controller="CloudTemplateController as template">
     <div id="header">
         <nav class="navbar navbar-default navbar-fixed-top">
             <div class="container-fluid">
@@ -9,7 +9,7 @@
 
                 <div class="pipeline-toggle btn-group"
 
-                     ng-show="template.hasComponents(ctrl.dashboard, ['SCM'])">
+                     ng-show="template.hasComponents(ctrl.dashboard)">
 
                     <span class="btn" ng-repeat="tab in template.tabs" ng-click="template.toggleView($index)"
                           ng-class="tab.name == template.widgetView ? 'btn-primary' : 'btn-default'">

--- a/UI/src/components/templates/cloud.js
+++ b/UI/src/components/templates/cloud.js
@@ -1,0 +1,30 @@
+/**
+ * Controller for the dashboard route.
+ * Render proper template.
+ */
+(function () {
+    'use strict';
+
+    angular
+        .module(HygieiaConfig.module)
+        .controller('CloudTemplateController', CloudTemplateController);
+
+    CapOneTemplateController.$inject = [];
+    function CapOneTemplateController() {
+        var ctrl = this;
+
+        ctrl.tabs = [
+            { name: "Cloud"}
+           ];
+
+        ctrl.widgetView = ctrl.tabs[0].name;
+        ctrl.toggleView = function (index) {
+            ctrl.widgetView = typeof ctrl.tabs[index] === 'undefined' ? ctrl.tabs[0].name : ctrl.tabs[index].name;
+        };
+
+        ctrl.hasComponents = function (dashboard) {
+            var hasAllComponents = true;
+            return hasAllComponents;
+        };
+    }
+})();

--- a/UI/src/components/templates/cloud.js
+++ b/UI/src/components/templates/cloud.js
@@ -9,8 +9,8 @@
         .module(HygieiaConfig.module)
         .controller('CloudTemplateController', CloudTemplateController);
 
-    CapOneTemplateController.$inject = [];
-    function CapOneTemplateController() {
+    CloudTemplateController.$inject = [];
+    function CloudTemplateController() {
         var ctrl = this;
 
         ctrl.tabs = [
@@ -22,9 +22,5 @@
             ctrl.widgetView = typeof ctrl.tabs[index] === 'undefined' ? ctrl.tabs[0].name : ctrl.tabs[index].name;
         };
 
-        ctrl.hasComponents = function (dashboard) {
-            var hasAllComponents = true;
-            return hasAllComponents;
-        };
     }
 })();

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -1,7 +1,9 @@
-# Default server configuration values
 dbname=dashboarddb
 dbusername=dashboarduser
 dbpassword=1qazxSw2
-dbhostport=10.205.81.28:27017
+dbhost=localhost
+dbport=27017
+dbreplicaset=false
+dbhostport=localhost:27017
 server.contextPath=/api
 server.port=8080


### PR DESCRIPTION
1. Code change for showing all the tabs moment the dashboard is created.
2. Ability to create standalone AWS cloud dashboard, This tab was earlier only visible if deploy widget was configured.
3. Modified Maintainers file to add new members

![image](https://cloud.githubusercontent.com/assets/6624821/18727305/0e60082e-8016-11e6-801d-7a3c253b7e71.png)

![image](https://cloud.githubusercontent.com/assets/6624821/18727467/c2b5130a-8016-11e6-91ca-3326e4de614c.png)


