### PR TITLE
Change will generate gzip of UI project dist folder

### DIFF
--- a/UI/assembly/bin.xml
+++ b/UI/assembly/bin.xml
@@ -1,0 +1,17 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>src</id>
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/dist/</directory>
+            <includes>
+                <include>*</include>
+            </includes>
+            <useDefaultExcludes>true</useDefaultExcludes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/UI/pom.xml
+++ b/UI/pom.xml
@@ -14,6 +14,23 @@
 
   <build>
     <plugins>
+        <plugin>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <version>2.6</version>
+            <configuration>
+                <descriptor>assembly/bin.xml</descriptor>
+                <tarLongFileMode>posix</tarLongFileMode>
+            </configuration>
+            <executions>
+                <execution>
+                    <id>create-archive</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>single</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
 	<plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION
Used Maven assembly plugin to assemble UI project dist folder in tar gzip format
This will allow folks to consume each build artifact from Maven Central, with out need to build from source