### PR TITLE
Bug Fix for Hygieia App version display

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -32,6 +32,22 @@
 
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>**/version.properties</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>**/version.properties</exclude>
+                </excludes>
+            </resource>
+        </resources>
         <finalName>api</finalName>
         <plugins>
             <plugin>

--- a/api/src/main/java/com/capitalone/dashboard/rest/PingController.java
+++ b/api/src/main/java/com/capitalone/dashboard/rest/PingController.java
@@ -1,6 +1,7 @@
 package com.capitalone.dashboard.rest;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
+@PropertySource(ignoreResourceNotFound=false,value= "classpath:version.properties")
 
 @RestController
 public class PingController {

--- a/api/src/main/java/com/capitalone/dashboard/rest/PingController.java
+++ b/api/src/main/java/com/capitalone/dashboard/rest/PingController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
-@PropertySource(ignoreResourceNotFound=false,value= "classpath:version.properties")
+@PropertySource(ignoreResourceNotFound=true,value= "classpath:version.properties")
 
 @RestController
 public class PingController {

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -7,4 +7,3 @@ dbreplicaset=false
 dbhostport=localhost:27017
 server.contextPath=/api
 server.port=8080
-version.number=@application.version.number@

--- a/api/src/main/resources/version.properties
+++ b/api/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+version.number=${project.version}


### PR DESCRIPTION
Spring boot tokenization works only for properties bundles inside the spring boot jar. To cater to this and preserve backwards compatibility.
- Introduced a new file called version.properties
- File gets updated by maven during build phase with current version.
- The property value is injected in the class requiring this.