### PR TITLE
Some documentation updates

### DIFF
--- a/getting_started.html
+++ b/getting_started.html
@@ -170,22 +170,23 @@ Plugin / Webhook
 
     <pre code>
       ...
-      <proxies>
+      &lt;proxies&gt;
              ...
-             <proxy>
-                     <id>your-proxy-id</id>
-                     <active>true</active>
-                     <protocol>http</protocol>
-                     <host>your.proxy.domain.name</host>
-                     <port>8080</port>
-                     <!-- For authenticated proxy, please set the following, as well -->
-                     <username>companyId999</username>
-                     <password>yourPassword</password>
-                     <nonProxyHosts>*.local</nonProxyHosts>
-             </proxy>
+             &lt;proxy&gt;
+                     &lt;id&gt;your-proxy-id&lt;/id&gt;
+                     &lt;active&gt;true&lt;/active&gt;
+                     &lt;protocol&gt;http&lt;/protocol&gt;
+                     &lt;host&gt;your.proxy.domain.name&lt;/host&gt;
+                     &lt;port&gt;8080&lt;/port&gt;
+                     &lt;!-- For authenticated proxy, please set the following, as well --&gt;
+                     &lt;username&gt;companyId999&lt;/username&gt;
+                     &lt;password&gt;yourPassword&lt;/password&gt;
+                     &lt;nonProxyHosts&gt;*.local&lt;/nonProxyHosts&gt;
+             &lt;/proxy&gt;
              ...
-       </proxies>
-      ...</pre code>
+       &lt;/proxies&gt;
+       ...
+    </pre code>
 
     <p>Additionally, set the following export variables:</p>
 

--- a/getting_started.html
+++ b/getting_started.html
@@ -13,7 +13,7 @@ slug: getting_started
   </h2>
 
   <p >Run the following command to build all components for Hygieia.</p>
-  <pre code>mvn clean install package</pre code>
+  <pre code>mvn clean install</pre code>
 
 
 


### PR DESCRIPTION
Just a couple minor updates to the getting started documentation.
- remove need for executing `package` goal in Maven since it already [executes at an earlier phase](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#Build_Lifecycle_Basics).
- fix the XML rendering for the Maven proxy configuration docs.

P.S. I've signed the contributor agreement.
