### PR TITLE
Add paging to Jenkins collector

### DIFF
--- a/collectors/build/jenkins/README.md
+++ b/collectors/build/jenkins/README.md
@@ -43,6 +43,9 @@ dbpassword=dbpass
 # Collector schedule (required)
 jenkins.cron=0 0/5 * * * *
 
+# The page size
+jenkins.pageSize=1000
+
 # Jenkins server (required) - Can provide multiple
 jenkins.servers[0]=http://jenkins.company.com
 

--- a/collectors/build/jenkins/docker/jenkins-build-properties-builder.sh
+++ b/collectors/build/jenkins/docker/jenkins-build-properties-builder.sh
@@ -70,6 +70,9 @@ dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
 #Collector schedule (required)
 jenkins.cron=${JENKINS_CRON:-0 0/5 * * * *}
 
+#The page size
+jenkins.pageSize=${JENKINS_PAGE_SIZE:-1000}
+
 #Jenkins server (required) - Can provide multiple
 #jenkins.servers[0]=http://jenkins.company.com
 #Another option: If using same username/password Jenkins auth - set username/apiKey to use HTTP Basic Auth (blank=no auth)

--- a/collectors/build/jenkins/src/main/java/com/capitalone/dashboard/collector/HudsonSettings.java
+++ b/collectors/build/jenkins/src/main/java/com/capitalone/dashboard/collector/HudsonSettings.java
@@ -20,6 +20,7 @@ public class HudsonSettings {
     private List<String> usernames;
     private List<String> apiKeys;
     private String dockerLocalHostIP; //null if not running in docker on http://localhost
+    private int pageSize;
 
     public String getCron() {
         return cron;
@@ -85,4 +86,12 @@ public class HudsonSettings {
     	}
         return localHostOverride;
     }
+    
+    public void setPageSize(int pageSize) {
+		this.pageSize = pageSize;
+	}
+    
+    public int getPageSize() {
+		return pageSize;
+	}
 }


### PR DESCRIPTION
- Adds paging to the jenkins collector. Page size defaults to 1000. Paging is necessary when there are a very large number of jobs as jenkins seems to choke if a rest response is too large.

@pxk5958 