### PR TITLE
Allow jira to pick up on multiple issue types

### DIFF
--- a/collectors/feature/jira/README.md
+++ b/collectors/feature/jira/README.md
@@ -64,8 +64,9 @@ feature.jiraOauthExpiretime=
 # the lowest level of Issues (e.g., "user story") specific to your Jira
 # instance.  Note:  You can retrieve your instance's IssueType Name
 # listings via the following URI:  https://[your-jira-domain-name]/rest/api/2/issuetype/
+# Multiple comma-separated values can be specified.
 #############################################################################
-feature.jiraIssueTypeId=Story
+feature.jiraIssueTypeNames=Story
 
 #############################################################################
 # In Jira, your instance will have its own custom field created for "sprint" or "timebox" details,

--- a/collectors/feature/jira/docker/jira-properties-builder.sh
+++ b/collectors/feature/jira/docker/jira-properties-builder.sh
@@ -101,7 +101,8 @@ feature.masterStartDate=${JIRA_MASTER_START_DATE:-2008-01-01T00:00:00.000000}
 # the lowest level of Issues (e.g., "user story") specific to your Jira
 # instance.  Note:  You can retrieve your instance's IssueType Name
 # listings via the following URI:  https://[your-jira-domain-name]/rest/api/2/issuetype/
-feature.jiraIssueTypeId=${JIRA_ISSUE_TYPE_ID:Story}
+# Multiple comma-separated values can be specified.
+feature.jiraIssueTypeNames=${JIRA_ISSUE_TYPE_NAMES:-Story}
 
 # In Jira, your instance will have its own custom field created for "sprint" or "timebox" details,
 # which includes a list of information.  This field allows you to specify that data field for your

--- a/collectors/feature/jira/src/main/java/com/capitalone/dashboard/client/DefaultJiraClient.java
+++ b/collectors/feature/jira/src/main/java/com/capitalone/dashboard/client/DefaultJiraClient.java
@@ -87,7 +87,7 @@ public class DefaultJiraClient implements JiraClient {
 				String startDateStr = QUERY_DATE_FORMAT.format(new Date(startTime));
 				
 				String query = featureWidgetQueries.getStoryQuery(startDateStr,
-						featureSettings.getJiraIssueTypeId(), featureSettings.getStoryQuery());
+						featureSettings.getJiraIssueTypeNames(), featureSettings.getStoryQuery());
 				
 				Promise<SearchResult> promisedRs = client.getSearchClient().searchJql(
 						query, featureSettings.getPageSize(), pageStart, DEFAULT_FIELDS);

--- a/collectors/feature/jira/src/main/java/com/capitalone/dashboard/client/story/StoryDataClientImpl.java
+++ b/collectors/feature/jira/src/main/java/com/capitalone/dashboard/client/story/StoryDataClientImpl.java
@@ -191,7 +191,11 @@ public class StoryDataClientImpl implements StoryDataClient {
 			
 			Map<String, String> issueEpics = new HashMap<>();
 			ObjectId jiraFeatureId = featureCollectorRepository.findByName(FeatureCollectorConstants.JIRA).getId();
-			String issueTypeName = featureSettings.getJiraIssueTypeId();
+			Set<String> issueTypeNames = new HashSet<>();
+			for (String issueTypeName : featureSettings.getJiraIssueTypeNames()) {
+				issueTypeNames.add(issueTypeName.toLowerCase(Locale.getDefault()));
+			}
+			
 			
 			for (Issue issue : currentPagedJiraRs) {
 				String issueId = TOOLS.sanitizeResponse(issue.getId());
@@ -207,7 +211,7 @@ public class StoryDataClientImpl implements StoryDataClient {
 				IssueField epic = fields.get(featureSettings.getJiraEpicIdFieldName());
 				IssueField sprint = fields.get(featureSettings.getJiraSprintDataFieldName());
 				
-				if (TOOLS.sanitizeResponse(issueType.getName()).equalsIgnoreCase(issueTypeName)) {
+				if (issueTypeNames.contains(TOOLS.sanitizeResponse(issueType.getName()).toLowerCase(Locale.getDefault()))) {
 					if (LOGGER.isDebugEnabled()) {
 						LOGGER.debug(String.format("[%-12s] %s", 
 								TOOLS.sanitizeResponse(issue.getKey()),
@@ -219,6 +223,10 @@ public class StoryDataClientImpl implements StoryDataClient {
 					
 					// ID
 					feature.setsId(TOOLS.sanitizeResponse(issue.getId()));
+					
+					// Type
+					feature.setsTypeId(issueType.getId().toString());
+					feature.setsTypeName(TOOLS.sanitizeResponse(issueType.getName()));
 
 					processFeatureData(feature, issue, fields);
 					

--- a/collectors/feature/jira/src/main/java/com/capitalone/dashboard/client/story/StoryDataClientImpl.java
+++ b/collectors/feature/jira/src/main/java/com/capitalone/dashboard/client/story/StoryDataClientImpl.java
@@ -225,7 +225,7 @@ public class StoryDataClientImpl implements StoryDataClient {
 					feature.setsId(TOOLS.sanitizeResponse(issue.getId()));
 					
 					// Type
-					feature.setsTypeId(issueType.getId().toString());
+					feature.setsTypeId(TOOLS.sanitizeResponse(issueType.getId()));
 					feature.setsTypeName(TOOLS.sanitizeResponse(issueType.getName()));
 
 					processFeatureData(feature, issue, fields);

--- a/collectors/feature/jira/src/main/java/com/capitalone/dashboard/util/FeatureSettings.java
+++ b/collectors/feature/jira/src/main/java/com/capitalone/dashboard/util/FeatureSettings.java
@@ -65,8 +65,9 @@ public class FeatureSettings {
 	 * <strong>Note:</strong> You can retrieve your instance's IssueType ID
 	 * listings via the following URI:
 	 * https://[your-jira-domain-name]/rest/api/2/issuetype/
+	 * Multiple comma-separated values can be specified.
 	 */
-	private String jiraIssueTypeId;
+	private String[] jiraIssueTypeNames;
 	/**
 	 * In Jira, your instance will have its own custom field created for "sprint" or "timebox" details, which includes a list of information.  This field allows you to specify that data field for your instance of Jira.
 	 * <p>
@@ -288,12 +289,12 @@ public class FeatureSettings {
 		this.jiraProxyPort = jiraProxyPort;
 	}
 	
-	public String getJiraIssueTypeId() {
-		return jiraIssueTypeId;
+	public String[] getJiraIssueTypeNames() {
+		return jiraIssueTypeNames;
 	}
 
-	public void setJiraIssueTypeId(String jiraIssueTypeId) {
-		this.jiraIssueTypeId = jiraIssueTypeId;
+	public void setJiraIssueTypeNames(String[] jiraIssueTypeNames) {
+		this.jiraIssueTypeNames = jiraIssueTypeNames;
 	}
 
 	public String getJiraSprintDataFieldName() {

--- a/collectors/feature/jira/src/main/java/com/capitalone/dashboard/util/FeatureWidgetQueries.java
+++ b/collectors/feature/jira/src/main/java/com/capitalone/dashboard/util/FeatureWidgetQueries.java
@@ -98,17 +98,21 @@ public class FeatureWidgetQueries {
 	 * @param changeDatePara
 	 *            The change date specified from which to pull data with a given
 	 *            query template.
-	 * @param issueType
-	 *            The Jira IssueType specified from which to pull data with a
+	 * @param issueTypes
+	 *            The Jira IssueTypes specified from which to pull data with a
 	 *            given query template.
 	 * @param queryName
 	 *            The source system query name (without the file type).
 	 * @return A given source system query, in String format.
 	 */
-	public String getStoryQuery(String changeDatePara, String issueType, String queryName) {
+	public String getStoryQuery(String changeDatePara, String[] issueTypes, String queryName) {
 		ST st = folder.getInstanceOf(queryName);
 		st.add("changeDate", changeDatePara);
-		st.add("issueType", issueType);
+		String[] issueTypesQuoted = new String[issueTypes.length];
+		for (int i = 0; i < issueTypes.length; i++) {
+			issueTypesQuoted[i] = "'" + issueTypes[i] + "'";
+		}
+		st.add("issueTypes", String.join(",", issueTypesQuoted));
 		String query = st.render();
 
 		return query;

--- a/collectors/feature/jira/src/main/resources/jiraapi-queries/story.st
+++ b/collectors/feature/jira/src/main/resources/jiraapi-queries/story.st
@@ -1,1 +1,1 @@
-story(changeDate,issueType) ::= "updatedDate>='$changeDate$' AND issueType='$issueType$' ORDER BY updated ASC"
+story(changeDate,issueTypes) ::= "updatedDate>='$changeDate$' AND issueType IN ($issueTypes$) ORDER BY updated ASC"

--- a/collectors/feature/jira/src/test/java/com/capitalone/dashboard/client/story/StoryDataClientImplTests.java
+++ b/collectors/feature/jira/src/test/java/com/capitalone/dashboard/client/story/StoryDataClientImplTests.java
@@ -79,7 +79,7 @@ public class StoryDataClientImplTests {
 		coreFeatureSettings.setDoingStatuses(Arrays.asList("IN PROGRESS"));
 		coreFeatureSettings.setDoneStatuses(Arrays.asList("CLOSED"));
 		
-		featureSettings.setJiraIssueTypeId("Story");
+		featureSettings.setJiraIssueTypeNames(new String[] {"Story"});
 		featureSettings.setJiraSprintDataFieldName("custom_sprint");
 		featureSettings.setJiraEpicIdFieldName("custom_epic");
 		featureSettings.setJiraStoryPointsFieldName("custom_storypoints");

--- a/collectors/feature/versionone/src/main/java/com/capitalone/dashboard/collector/StoryDataClient.java
+++ b/collectors/feature/versionone/src/main/java/com/capitalone/dashboard/collector/StoryDataClient.java
@@ -84,6 +84,12 @@ public class StoryDataClient extends BaseClient {
 
 			// sState
 			feature.setsState(getJSONString(dataMainObj, "AssetState"));
+			
+			// sTypeID
+			feature.setsTypeId("");
+			
+			// sTypeName
+			feature.setsTypeName(getJSONString(dataMainObj, "AssetType"));
 
 			// sEstimate
 			feature.setsEstimate(getJSONString(dataMainObj, "Estimate"));

--- a/collectors/feature/versionone/src/main/resources/v1api-queries/story.st
+++ b/collectors/feature/versionone/src/main/resources/v1api-queries/story.st
@@ -4,6 +4,7 @@ select:
  - Name
  - Status.Name
  - AssetState
+ - AssetType
  - Estimate
  - IsDeleted
  - ChangeDate

--- a/core/src/main/java/com/capitalone/dashboard/model/Feature.java
+++ b/core/src/main/java/com/capitalone/dashboard/model/Feature.java
@@ -40,6 +40,8 @@ public class Feature extends BaseModel {
 	private String sId;
 	private String sNumber;
 	private String sName;
+	private String sTypeId;
+	private String sTypeName;
 	private String sStatus;
 	private String sState;
 	private String sEstimate; // estimate in story points
@@ -138,6 +140,22 @@ public class Feature extends BaseModel {
 
 	public void setsName(String sName) {
 		this.sName = sName;
+	}
+	
+	public String getsTypeId() {
+		return sTypeId;
+	}
+
+	public void setsTypeId(String sTypeId) {
+		this.sTypeId = sTypeId;
+	}
+
+	public String getsTypeName() {
+		return sTypeName;
+	}
+
+	public void setsTypeName(String sTypeName) {
+		this.sTypeName = sTypeName;
 	}
 
 	public String getsStatus() {


### PR DESCRIPTION
At present the jira collector can only collect on one issue type. We want to be able to pick up estimates assigned to other types (such as investigation spikes and defects). This change allows multiple issue types to be specified in the config.

Note the name of the config item was corrected so configs will have to be updated.

@pxk5958 