### PR TITLE
Gitlab Custom Protocol/Port

### DIFF
--- a/collectors/scm/gitlab/README.md
+++ b/collectors/scm/gitlab/README.md
@@ -48,13 +48,19 @@ logging.file=./logs/gitlab.log
 #Collector schedule (required)
 gitlab.cron=0 0/1 * * * *
 
-#Gitlab host (optional)
+#Gitlab host (optional, defaults to "gitlab.com")
 gitlab.host=gitlab.company.com
+
+#Gitlab protocol (optional, defaults to "http")
+gitlab.protocol=http
+
+#Gitlab port (optional, defaults to protocol default port)
+gitlab.port=80
 
 #If your instance of Gitlab is using a self signed certificate, set to true, default is false
 gitlab.selfSignedCertificate=false
 
-#set apiKey to use HTTPS Auth
+#Gitlab API Token (required, token of user the collector will use by default, can be overriden on a per repo basis from the UI. API token provided by Gitlab)
 gitlab.apiToken=
 
 #Maximum number of days to go back in time when fetching commits

--- a/collectors/scm/gitlab/README.md
+++ b/collectors/scm/gitlab/README.md
@@ -18,11 +18,11 @@ java -JAR gitlab-collector.jar
 
 ## application.properties
 
-You will need to provide an **application.properties** file that contains information about how to connect to the Dashboard MongoDB database instance, as well as properties the Github collector requires. See the Spring Boot [documentation](http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-external-config-application-property-files) for information about sourcing this properties file.
+You will need to provide an **application.properties** file that contains information about how to connect to the Dashboard MongoDB database instance, as well as properties the Gitlab collector requires. See the Spring Boot [documentation](http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-external-config-application-property-files) for information about sourcing this properties file.
 
 ### Sample application.properties file
 
-```#Database Name 
+``` 
 # Database Name
 dbname=dashboard
 

--- a/collectors/scm/gitlab/src/main/java/com/capitalone/dashboard/collecteur/GitlabSettings.java
+++ b/collectors/scm/gitlab/src/main/java/com/capitalone/dashboard/collecteur/GitlabSettings.java
@@ -15,7 +15,9 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "gitlab")
 public class GitlabSettings {
     private String cron;
+    private String protocol;
     private String host;
+    private String port;
     private String apiToken;
 	private int firstRunHistoryDays;
 	private boolean selfSignedCertificate;
@@ -28,7 +30,15 @@ public class GitlabSettings {
         this.cron = cron;
     }
 
-    public String getApiToken() {
+    public String getProtocol() {
+		return protocol;
+	}
+
+	public void setProtocol(String protocol) {
+		this.protocol = protocol;
+	}
+
+	public String getApiToken() {
         return apiToken;
     }
 
@@ -42,6 +52,14 @@ public class GitlabSettings {
 
 	public void setHost(String host) {
 		this.host = host;
+	}
+
+	public String getPort() {
+		return port;
+	}
+
+	public void setPort(String port) {
+		this.port = port;
 	}
 
 	public int getFirstRunHistoryDays() {

--- a/collectors/scm/gitlab/src/main/java/com/capitalone/dashboard/collecteur/GitlabUrlUtility.java
+++ b/collectors/scm/gitlab/src/main/java/com/capitalone/dashboard/collecteur/GitlabUrlUtility.java
@@ -25,7 +25,7 @@ public class GitlabUrlUtility {
 	private GitlabSettings gitlabSettings;
 	
 	private static final String GIT_EXTENSION = ".git";
-	private static final String PROTOCOL = "https";
+	private static final String DEFAULT_PROTOCOL = "http";
     private static final String SEGMENT_API = "/api/v3/projects/";
 	private static final String COMMITS_API = "/repository/commits/";
 	private static final String DATE_QUERY_PARAM_KEY = "since";
@@ -45,13 +45,15 @@ public class GitlabUrlUtility {
             repoUrl = StringUtils.removeEnd(repoUrl, GIT_EXTENSION);
         }
         
+        String protocol = StringUtils.isBlank(gitlabSettings.getProtocol()) ? DEFAULT_PROTOCOL : gitlabSettings.getProtocol();
 		String repoName = getRepoName(repoUrl);
 		String host = getRepoHost();
 		String date = getDateForCommits(repo, firstRun);
 
 		UriComponentsBuilder builder = UriComponentsBuilder.newInstance();
-		URI uri = builder.scheme(PROTOCOL)
+		URI uri = builder.scheme(protocol)
 				.host(host)
+				.port(gitlabSettings.getPort())
 				.path(SEGMENT_API)
 				.path(repoName)
 				.path(COMMITS_API)

--- a/collectors/scm/gitlab/src/test/java/com/capitalone/dashboard/collecteur/GitlabUrlUtilityTest.java
+++ b/collectors/scm/gitlab/src/test/java/com/capitalone/dashboard/collecteur/GitlabUrlUtilityTest.java
@@ -34,7 +34,7 @@ public class GitlabUrlUtilityTest {
 		
 		URI result  = gitlabUrlUtility.buildApiUrl(gitlabRepo, true, 100);
 		
-		assertEquals("https", result.getScheme());
+		assertEquals("http", result.getScheme());
 		assertEquals("gitlab.com", result.getHost());
 		assertEquals("/api/v3/projects/namespace%2FHygieia/repository/commits/", result.getRawPath());
 		assertTrue(result.getQuery().contains("ref_name=master"));
@@ -46,6 +46,22 @@ public class GitlabUrlUtilityTest {
 	public void shouldBuildApiUrlWithGitExtension() {
 		when(gitlabRepo.getRepoUrl()).thenReturn("https://domain.org/namespace/Hygieia.git");
 		when(gitlabRepo.getBranch()).thenReturn("master");
+		
+		URI result  = gitlabUrlUtility.buildApiUrl(gitlabRepo, true, 100);
+		
+		assertEquals("http", result.getScheme());
+		assertEquals("gitlab.com", result.getHost());
+		assertEquals("/api/v3/projects/namespace%2FHygieia/repository/commits/", result.getRawPath());
+		assertTrue(result.getQuery().contains("ref_name=master"));
+		assertTrue(result.getQuery().contains("per_page=100"));
+		assertTrue(result.getQuery().contains("since="));
+	}
+	
+	@Test
+	public void shouldBuildApiUrlWithCustomProtocol() {
+		when(gitlabRepo.getRepoUrl()).thenReturn("https://domain.org/namespace/Hygieia");
+		when(gitlabRepo.getBranch()).thenReturn("master");
+		when(gitlabSettings.getProtocol()).thenReturn("https");
 		
 		URI result  = gitlabUrlUtility.buildApiUrl(gitlabRepo, true, 100);
 		
@@ -65,9 +81,27 @@ public class GitlabUrlUtilityTest {
 		
 		URI result  = gitlabUrlUtility.buildApiUrl(gitlabRepo, true, 100);
 		
-		assertEquals("https", result.getScheme());
+		assertEquals("http", result.getScheme());
 		assertEquals("customhost.com", result.getHost());
 		assertEquals("/api/v3/projects/namespace%2FHygieia/repository/commits/", result.getRawPath());
+		assertTrue(result.getQuery().contains("ref_name=master"));
+		assertTrue(result.getQuery().contains("per_page=100"));
+		assertTrue(result.getQuery().contains("since="));
+	}
+	
+	@Test
+	public void shouldBuildApiUrlWithCustomPort() {
+		when(gitlabRepo.getRepoUrl()).thenReturn("https://domain.org/namespace/Hygieia");
+		when(gitlabRepo.getBranch()).thenReturn("master");
+		when(gitlabSettings.getHost()).thenReturn("customhost.com");
+		when(gitlabSettings.getPort()).thenReturn("443");
+		
+		URI result  = gitlabUrlUtility.buildApiUrl(gitlabRepo, true, 100);
+		
+		assertEquals("http", result.getScheme());
+		assertEquals("customhost.com", result.getHost());
+		assertEquals("/api/v3/projects/namespace%2FHygieia/repository/commits/", result.getRawPath());
+		assertEquals(443, result.getPort());
 		assertTrue(result.getQuery().contains("ref_name=master"));
 		assertTrue(result.getQuery().contains("per_page=100"));
 		assertTrue(result.getQuery().contains("since="));
@@ -81,7 +115,7 @@ public class GitlabUrlUtilityTest {
 		
 		URI result  = gitlabUrlUtility.buildApiUrl(gitlabRepo, true, 100);
 		
-		assertEquals("https", result.getScheme());
+		assertEquals("http", result.getScheme());
 		assertEquals("gitlab.com", result.getHost());
 		assertEquals("/api/v3/projects/namespace%2FHygieia/repository/commits/", result.getRawPath());
 		assertTrue(result.getQuery().contains("ref_name=master"));
@@ -97,7 +131,7 @@ public class GitlabUrlUtilityTest {
 		
 		URI result  = gitlabUrlUtility.buildApiUrl(gitlabRepo, false, 100);
 		
-		assertEquals("https", result.getScheme());
+		assertEquals("http", result.getScheme());
 		assertEquals("gitlab.com", result.getHost());
 		assertEquals("/api/v3/projects/namespace%2FHygieia/repository/commits/", result.getRawPath());
 		assertTrue(result.getQuery().contains("ref_name=master"));


### PR DESCRIPTION
These changes allow users to choose which protocol and port to use when querying Gitlab's API.  Also added some more information in the Readme about running the collector and which properties are required.

Resolves #957