### PR TITLE
Fixed log file path for all collectors

### DIFF
--- a/collectors/artifact/artifactory/src/main/resources/logback.xml
+++ b/collectors/artifact/artifactory/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
  <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- rollover daily -->
-      <fileNamePattern>artifactcollector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>logs/artifactcollector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <timeBasedFileNamingAndTriggeringPolicy
             class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
         <!-- or whenever the file size reaches 100MB -->

--- a/collectors/build/bamboo/src/main/resources/logback.xml
+++ b/collectors/build/bamboo/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
  <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- rollover daily -->
-      <fileNamePattern>buildcollector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>logs/buildcollector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <timeBasedFileNamingAndTriggeringPolicy
             class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
         <!-- or whenever the file size reaches 100MB -->

--- a/collectors/build/jenkins-cucumber/src/main/resources/logback.xml
+++ b/collectors/build/jenkins-cucumber/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
  <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- rollover daily -->
-      <fileNamePattern>cucumber-jenkins-collector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>logs/cucumber-jenkins-collector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <timeBasedFileNamingAndTriggeringPolicy
             class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
         <!-- or whenever the file size reaches 100MB -->

--- a/collectors/build/jenkins/src/main/resources/logback.xml
+++ b/collectors/build/jenkins/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
  <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- rollover daily -->
-      <fileNamePattern>buildcollector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>logs/buildcollector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <timeBasedFileNamingAndTriggeringPolicy
             class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
         <!-- or whenever the file size reaches 100MB -->

--- a/collectors/build/sonar/src/main/resources/logback.xml
+++ b/collectors/build/sonar/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
  <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- rollover daily -->
-      <fileNamePattern>codequalitycollector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>logs/codequalitycollector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <timeBasedFileNamingAndTriggeringPolicy
             class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
         <!-- or whenever the file size reaches 100MB -->

--- a/collectors/deploy/udeploy/src/main/resources/logback.xml
+++ b/collectors/deploy/udeploy/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
  <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- rollover daily -->
-      <fileNamePattern>deploycollector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>logs/deploycollector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <timeBasedFileNamingAndTriggeringPolicy
             class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
         <!-- or whenever the file size reaches 100MB -->

--- a/collectors/deploy/xldeploy/src/main/resources/logback.xml
+++ b/collectors/deploy/xldeploy/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
  <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- rollover daily -->
-      <fileNamePattern>deploycollector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>logs/deploycollector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <timeBasedFileNamingAndTriggeringPolicy
             class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
         <!-- or whenever the file size reaches 100MB -->

--- a/collectors/feature/jira/src/main/resources/logback.xml
+++ b/collectors/feature/jira/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
  <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- rollover daily -->
-      <fileNamePattern>jiracollector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>logs/jiracollector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <timeBasedFileNamingAndTriggeringPolicy
             class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
         <!-- or whenever the file size reaches 100MB -->

--- a/collectors/feature/versionone/src/main/resources/logback.xml
+++ b/collectors/feature/versionone/src/main/resources/logback.xml
@@ -10,7 +10,7 @@
     <!-- <file>/prod/msp/logs/jmssp_logs/jssp-app-log</file> -->
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- rollover daily -->
-      <fileNamePattern>versiononecollector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>logs/versiononecollector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <timeBasedFileNamingAndTriggeringPolicy
             class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
         <!-- or whenever the file size reaches 100MB -->

--- a/collectors/scm/bitbucket/src/main/resources/logback.xml
+++ b/collectors/scm/bitbucket/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
  <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- rollover daily -->
-      <fileNamePattern>bitbucket-collector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>logs/bitbucket-collector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <timeBasedFileNamingAndTriggeringPolicy
             class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
         <!-- or whenever the file size reaches 100MB -->

--- a/collectors/scm/github/src/main/resources/logback.xml
+++ b/collectors/scm/github/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
  <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- rollover daily -->
-      <fileNamePattern>github-collector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>logs/github-collector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <timeBasedFileNamingAndTriggeringPolicy
             class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
         <!-- or whenever the file size reaches 100MB -->

--- a/collectors/scm/subversion/src/main/resources/logback.xml
+++ b/collectors/scm/subversion/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
  <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- rollover daily -->
-      <fileNamePattern>sourcecode-collector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>logs/sourcecode-collector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <timeBasedFileNamingAndTriggeringPolicy
             class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
         <!-- or whenever the file size reaches 100MB -->


### PR DESCRIPTION
When running in docker logs were getting lost because they were not being placed in the correct location (logs) that was mounted.

@pxk5958 

Fixes #988