### PR TITLE
correcting if condition on JENKINS_OP_CENTER

### DIFF
--- a/collectors/build/jenkins/docker/jenkins-build-properties-builder.sh
+++ b/collectors/build/jenkins/docker/jenkins-build-properties-builder.sh
@@ -121,7 +121,7 @@ jenkins.dockerLocalHostIP=${DOCKER_LOCALHOST}
 
 EOF
 
-if ( "$JENKINS_OP_CENTER" != "" )
+if [ "$JENKINS_OP_CENTER" != "" ]
 then
 
 	cat >> $PROP_FILE <<EOF


### PR DESCRIPTION
Problem: The Hygieia Jenkins Collector docker container fails on startup. The docker file runs a shell script to build property file. This shell script has an incorrectly declared if condition (was using parenthesis instead of brackets).