### PR TITLE
Fix for product dashboard sometimes not displaying data right away #864

### DIFF
--- a/UI/src/components/widgets/product/js/commit-data.js
+++ b/UI/src/components/widgets/product/js/commit-data.js
@@ -17,6 +17,7 @@
         var db = dependencies.db,
             configuredTeam = dependencies.configuredTeam,
             $q = dependencies.$q,
+            $timeout = dependencies.$timeout,
             isReload = dependencies.isReload,
             pipelineData = dependencies.pipelineData,
             nowTimestamp = dependencies.nowTimestamp,
@@ -339,11 +340,13 @@
                         teamStageData[stageName].needsConfiguration = team.unmappedStages.indexOf(stageName) != -1;
                     }
                 }
-
-                dependencies.setTeamData(team.collectorItemId, {
-                    stages: teamStageData,
-                    prod: teamProdData
-                });
+                
+                $timeout(function() {
+	                dependencies.setTeamData(team.collectorItemId, {
+	                    stages: teamStageData,
+	                    prod: teamProdData
+	                });
+	            });
             });
         }
 

--- a/UI/src/components/widgets/product/view.js
+++ b/UI/src/components/widgets/product/view.js
@@ -426,6 +426,7 @@
                     cleanseData: cleanseData,
                     pipelineData: pipelineData,
                     $q: $q,
+                    $timeout: $timeout,
                     ctrlStages: ctrlStages
                 };
 


### PR DESCRIPTION
Fixes the dashboard sometimes not showing data right away due to a timing issue. I think it has to do with the order the asynchronous rest calls come back in. This wraps the setTeamData method into a $timeout function which puts it at the end of the event queue and causes a $scope.$apply() to be run after it is finished. I don't know if the $timeout wrap is necessary (as opposed to using $scope.$apply() but that is what other js functions do so I followed suit.