### PR TITLE
changes to allow collecting builds from a workflow type jenkins job

### DIFF
--- a/collectors/build/jenkins/src/main/java/com/capitalone/dashboard/collector/DefaultHudsonClient.java
+++ b/collectors/build/jenkins/src/main/java/com/capitalone/dashboard/collector/DefaultHudsonClient.java
@@ -1,11 +1,23 @@
 package com.capitalone.dashboard.collector;
 
-import com.capitalone.dashboard.model.Build;
-import com.capitalone.dashboard.model.BuildStatus;
-import com.capitalone.dashboard.model.HudsonJob;
-import com.capitalone.dashboard.model.RepoBranch;
-import com.capitalone.dashboard.model.SCM;
-import com.capitalone.dashboard.util.Supplier;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -24,23 +36,12 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestOperations;
 
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import com.capitalone.dashboard.model.Build;
+import com.capitalone.dashboard.model.BuildStatus;
+import com.capitalone.dashboard.model.HudsonJob;
+import com.capitalone.dashboard.model.RepoBranch;
+import com.capitalone.dashboard.model.SCM;
+import com.capitalone.dashboard.util.Supplier;
 
 
 /**
@@ -232,6 +233,7 @@ public class DefaultHudsonClient implements HudsonClient {
      */
     private void addChangeSets(Build build, JSONObject buildJson) {
         JSONObject changeSet = (JSONObject) buildJson.get("changeSet");
+        if(changeSet == null) { return; }
         String scmType = getString(changeSet, "kind");
         Map<String, RepoBranch> revisionToUrl = new HashMap<>();
 

--- a/collectors/build/jenkins/src/test/java/com/capitalone/dashboard/collector/DefaultHudsonClientTests.java
+++ b/collectors/build/jenkins/src/test/java/com/capitalone/dashboard/collector/DefaultHudsonClientTests.java
@@ -1,10 +1,25 @@
 package com.capitalone.dashboard.collector;
 
-import com.capitalone.dashboard.model.Build;
-import com.capitalone.dashboard.model.BuildStatus;
-import com.capitalone.dashboard.model.HudsonJob;
-import com.capitalone.dashboard.model.SCM;
-import com.capitalone.dashboard.util.Supplier;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,24 +34,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestOperations;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URL;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import com.capitalone.dashboard.model.Build;
+import com.capitalone.dashboard.model.BuildStatus;
+import com.capitalone.dashboard.model.HudsonJob;
+import com.capitalone.dashboard.model.SCM;
+import com.capitalone.dashboard.util.Supplier;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultHudsonClientTests {
@@ -418,6 +420,24 @@ public class DefaultHudsonClientTests {
         assertThat(build.getStartedBy(), is(nullValue()));
         assertThat(build.getSourceChangeSet().size(), is(0));
         assertThat(build.getCodeRepos().size(), is(0));
+    }
+    
+    @Test
+    public void buildDetails_noChangeSet() throws Exception {
+        when(rest.exchange(Matchers.any(URI.class), eq(HttpMethod.GET), Matchers.any(HttpEntity.class), eq(String.class)))
+                .thenReturn(new ResponseEntity<>(getJson("buildDetails_noChangeSet.json"), HttpStatus.OK));
+
+        Build build = hudsonClient.getBuildDetails("http://server/job/job2/2/", "http://server");
+
+        assertThat(build.getTimestamp(), notNullValue());
+        assertThat(build.getNumber(), is("483"));
+        assertThat(build.getBuildUrl(), is(URL_TEST));
+        assertThat(build.getStartTime(), is(5671281415000L));
+        assertThat(build.getEndTime(), is(5671286423495L));
+        assertThat(build.getDuration(), is(5008495L));
+        assertThat(build.getBuildStatus(), is(BuildStatus.Failure));
+        assertThat(build.getStartedBy(), nullValue());
+        assertThat(build.getSourceChangeSet(), hasSize(0));
     }
 
     private void assertBuild(Build build, String number, String url) {

--- a/collectors/build/jenkins/src/test/resources/com/capitalone/dashboard/collector/buildDetails_noChangeSet.json
+++ b/collectors/build/jenkins/src/test/resources/com/capitalone/dashboard/collector/buildDetails_noChangeSet.json
@@ -1,0 +1,8 @@
+{
+  "building": false,
+  "duration": 5008495,
+  "number": 483,
+  "result": "FAILURE",
+  "timestamp": 5671281415000,
+  "url": "https://builds.apache.org/job/GreatestBuildJob/483/"
+}


### PR DESCRIPTION
Problem: When the Jenkins collector runs and encounters a workflow type job ("_class":"org.jenkinsci.plugins.workflow.job.WorkflowRun"), the collector throws an exception since workflow type jobs don't have changeSets. This is a fix to add a null check and immediately exit from the method when there are no changeSets to build, but still allow to collect build information from a workflow job.