### PR TITLE
Disabled browser-sync ghost mode, by default

### DIFF
--- a/UI/README.md
+++ b/UI/README.md
@@ -62,6 +62,11 @@ Local Testing with Mocks:
  gulp serve --local true
 ```
 
+Using browser-sync's [`ghostMode`](https://www.browsersync.io/docs/options#option-ghostMode) functionality:
+```bash
+gulp serve:ghost-mode
+```
+
 or you can run via maven from UI project root folder
  ```bash
  mvn clean package integration-test
@@ -87,7 +92,7 @@ docker run -t -p 8088:80 --link hygieia-api -i hygieia-ui:latest
 ```
 
 ### API check
- 
+
 #### API layer successfully connected
 ![Image](/media/images/apiup.png)
 

--- a/UI/gulpfile.js
+++ b/UI/gulpfile.js
@@ -94,65 +94,71 @@ gulp.task('build', function(callback) {
 // run the build task, start up a browser, then
 // watch the different file locations and execute
 // the relevant tasks
-gulp.task('serve', ['build'], function() {
-    /*
-     * Location of your backend server
-     */
-    var proxyTarget = config.api || 'http://localhost:8080';
+function server(ghostMode) {
+  ghostMode = typeof ghostMode == 'undefined' ? false : true
+  return function () {
+      /*
+       * Location of your backend server
+       */
+      var proxyTarget = config.api || 'http://localhost:8080';
 
-    var proxy = httpProxy.createProxyServer({
-        target: proxyTarget
-    });
+      var proxy = httpProxy.createProxyServer({
+          target: proxyTarget
+      });
 
-    proxy.on('error', function(error, req, res) {
-        res.writeHead(500, {
-            'Content-Type': 'text/plain'
-        });
+      proxy.on('error', function(error, req, res) {
+          res.writeHead(500, {
+              'Content-Type': 'text/plain'
+          });
 
-        console.error(chalk.red('[Proxy]'), error);
-    });
+          console.error(chalk.red('[Proxy]'), error);
+      });
 
-    /*
-     * The proxy middleware is an Express middleware added to BrowserSync to
-     * handle backend request and proxy them to your backend.
-     */
-    function proxyMiddleware(req, res, next) {
-        /*
-         * Proxy the REST API.
-         */
-        if (/^\/api\/.*/.test(req.url)) {
-            proxy.web(req, res);
-        } else {
-            next();
-        }
-    }
+      /*
+       * The proxy middleware is an Express middleware added to BrowserSync to
+       * handle backend request and proxy them to your backend.
+       */
+      function proxyMiddleware(req, res, next) {
+          /*
+           * Proxy the REST API.
+           */
+          if (/^\/api\/.*/.test(req.url)) {
+              proxy.web(req, res);
+          } else {
+              next();
+          }
+      }
 
-    browserSync.init({
-        server: {
-            baseDir: hygieia.dist,
-            startPath: '/',
-            middleware: [proxyMiddleware]
-        }
-    });
+      browserSync.init({
+          server: {
+              baseDir: hygieia.dist,
+              startPath: '/',
+              middleware: [proxyMiddleware]
+          },
+          ghostMode: ghostMode
+      });
 
-    gulp.watch(jsFiles).on('change', function() {
-        runSequence(['js','html'], browserSync.reload);
-    });
+      gulp.watch(jsFiles).on('change', function() {
+          runSequence(['js','html'], browserSync.reload);
+      });
 
-    // watch the less files in addition to the themes
-    gulp.watch(themeFiles.concat(widgetStyleFiles)).on('change', function() {
-        runSequence('themes', browserSync.reload);
-    });
+      // watch the less files in addition to the themes
+      gulp.watch(themeFiles.concat(widgetStyleFiles)).on('change', function() {
+          runSequence('themes', browserSync.reload);
+      });
 
-    gulp.watch(viewFiles).on('change', function() {
-        runSequence('views', browserSync.reload);
-    });
+      gulp.watch(viewFiles).on('change', function() {
+          runSequence('views', browserSync.reload);
+      });
 
-    gulp.watch(testDataFiles).on('change', function() {
-        runSequence('test-data');
-    });
-});
+      gulp.watch(testDataFiles).on('change', function() {
+          runSequence('test-data');
+      });
+  }
+}
 
+gulp.task('serve', ['build'], server());
+gulp.task('serve:ghost-mode', ['build'], server(true))
 
 
 /*******************************
@@ -264,7 +270,7 @@ gulp.task('html', function() {
         // replace inject:js with script references to all the files in the following sources
         .pipe(inject(gulp.src(
     		!!argv.prod ? ['src/app/app.js'] : jsFiles)
-    		.pipe(order(['app/app.js', 'app/dashboard/core/module.js', 'app/**/*.js', 'components/**/*.js'])), 
+    		.pipe(order(['app/app.js', 'app/dashboard/core/module.js', 'app/**/*.js', 'components/**/*.js'])),
     		{ name: 'hygieia', ignorePath: 'src', addRootSlash: false }))
 
         // replace custom placeholders with our configured values


### PR DESCRIPTION
Since this has been the source of several issues, I think it best to disable browser-sync's [`ghostMode`](https://www.browsersync.io/docs/options/#option-ghostMode) feature, by default.

Ghost mode can be enabled by running `gulp serve:ghost-mode` if you require this functionality.

Resolves #1016