### PR TITLE
Correct logback on gitlab-git-collector

### DIFF
--- a/collectors/scm/gitlab/src/main/resources/logback.xml
+++ b/collectors/scm/gitlab/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
     <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- rollover daily -->
-            <fileNamePattern>Gitlab-git-collector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <fileNamePattern>logs/gitlab-git-collector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <timeBasedFileNamingAndTriggeringPolicy
                     class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <!-- or whenever the file size reaches 100MB -->


### PR DESCRIPTION
Adjusted the logback configuration on the gitlab-git-collector to keep it consistent with the other Hygieia collectors.