### PR TITLE
Fixed issues in version one properties builder shell file

### DIFF
--- a/collectors/feature/versionone/docker/versionone-properties-builder.sh
+++ b/collectors/feature/versionone/docker/versionone-properties-builder.sh
@@ -41,6 +41,9 @@ dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
 #Database Password - default is blank
 dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
 
+#Collector schedule (required)
+feature.cron=${VERSIONONE_CRON:-0 0/5 * * * *}
+
 #Page size for data calls (VersionOne recommended 2000)
 feature.pageSize=${VERSIONONE_PAGE_SIZE:-2000}
 
@@ -54,7 +57,7 @@ feature.projectQuery=${VERSIONONE_PROJECT_QUERY:-projectinfo}
 feature.memberQuery=${VERSIONONE_MEMBBER_QUERY:-memberinfo}
 feature.sprintQuery=${VERSIONONE_SPRINT_QUERY:-sprintinfo}
 feature.teamQuery=${VERSIONONE_TEAM_QUERY:-teaminfo}
-feature.trendingQuery${{VERSIONONE_TRENDING_QUERY:-trendinginfo}
+feature.trendingQuery${VERSIONONE_TRENDING_QUERY:-trendinginfo}
 
 # Trending Query:  Number of days in a sprint (not-required)
 feature.sprintDays=${VERSIONONE_SPRINT_DAYS:-60}


### PR DESCRIPTION
When using docker to create a versionone collector, we found that there was no properties file was being created. This was due to a syntax error in the properties builder script when copying the values to the properties file. Once that file was created, the was no CRON being specified. CRON has been added to the versionone properties builder as well as the syntax errors being corrected.