### PR TITLE
Gitlab feature collector - optional server port

### DIFF
--- a/collectors/feature/gitlab/src/main/java/com/capitalone/dashboard/gitlab/GitlabUriUtility.java
+++ b/collectors/feature/gitlab/src/main/java/com/capitalone/dashboard/gitlab/GitlabUriUtility.java
@@ -88,9 +88,13 @@ public class GitlabUriUtility {
 		String host = StringUtils.isBlank(settings.getHost()) ? DEFAULT_HOST : settings.getHost();
 		
 		UriComponentsBuilder builder = UriComponentsBuilder.newInstance();
+		
+		if(StringUtils.isNotBlank(settings.getPort())) {
+			builder.port(settings.getPort());
+		}
+		
 		return builder.scheme(protocol)
 				.host(host)
-				.port(settings.getPort())
 				.pathSegment(API_PATH_SEGMENT)
 				.pathSegment(VERSION_PATH_SEGMENT)
 				.queryParam(RESULT_PER_PAGE_QUERY_PARAM_KEY, RESULTS_PER_PAGE);

--- a/collectors/feature/gitlab/src/test/java/com/capitalone/dashboard/gitlab/GitlabUriUtilityTest.java
+++ b/collectors/feature/gitlab/src/test/java/com/capitalone/dashboard/gitlab/GitlabUriUtilityTest.java
@@ -38,6 +38,13 @@ public class GitlabUriUtilityTest {
 	}
 	
 	@Test
+	public void shouldBuildTeamUriWithNoPort() {
+		when(settings.getPort()).thenReturn("");
+		URI result = urlUtility.buildTeamsUri(); 
+		assertEquals("http://gitlab.com/api/v3/groups?per_page=100", result.toString());
+	}
+	
+	@Test
 	public void shouldBuildBoardsUriWithCustomProtocol() {
 		when(settings.getProtocol()).thenReturn("https");
 		URI result = urlUtility.buildBoardsUri("23"); 


### PR DESCRIPTION
Currently the Gitlab feature collector accepts a Gitlab server with a corresponding port in the properties builder file. If the collector is started without a Gitlab port supplied, the port is processed as "", throwing a Number Format Exception. The logic in the URI builder has been updated to not include the port if it is an empty string.