### PR TITLE
Fix readme markdown issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ### What is Hygieia℠
 
-#####Pronunciation:      hi-gee-ya (origin Greek)
+##### Pronunciation:      hi-gee-ya (origin Greek)
 Hygieia℠ is a single, configurable, easy to use dashboard to visualize near real-time status of the entire delivery pipeline.
 
 Please view a video below to see Hygieia℠ in action
@@ -41,8 +41,8 @@ For the past two years, we’ve looked for DevOps visualization tools in the com
 ### Contributors :
 We welcome Your interest in Capital One’s Open Source Projects (the “Project”). Any Contributor to the Project must accept and sign an Agreement indicating agreement to the license terms below. Except for the license granted in this Agreement to Capital One and to recipients of software distributed by Capital One, You reserve all right, title, and interest in and to Your Contributions; this Agreement does not impact Your rights to use Your own Contributions for any other purpose.
 
-##### [Link to Individual Agreement] (https://docs.google.com/forms/d/19LpBBjykHPox18vrZvBbZUcK6gQTj7qv1O5hCduAZFU/viewform)
-##### [Link to Corporate Agreement] (https://docs.google.com/forms/d/e/1FAIpQLSeAbobIPLCVZD_ccgtMWBDAcN68oqbAJBQyDTSAQ1AkYuCp_g/viewform?usp=send_form)
+##### [Link to Individual Agreement](https://docs.google.com/forms/d/19LpBBjykHPox18vrZvBbZUcK6gQTj7qv1O5hCduAZFU/viewform)
+##### [Link to Corporate Agreement](https://docs.google.com/forms/d/e/1FAIpQLSeAbobIPLCVZD_ccgtMWBDAcN68oqbAJBQyDTSAQ1AkYuCp_g/viewform?usp=send_form)
 
 This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to honor this code.
 


### PR DESCRIPTION
Some links and headers were broken on the readme, most likely caused by [Github's markdown changes](https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown)