### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ### What is Hygieia℠
 
-#####Pronunciation:      hi-gee-ya (origin Greek)
+##### Pronunciation:      hi-gee-ya (origin Greek)
 Hygieia℠ is a single, configurable, easy to use dashboard to visualize near real-time status of the entire delivery pipeline.
 
 Please view a video below to see Hygieia℠ in action

--- a/Setup.md
+++ b/Setup.md
@@ -207,19 +207,19 @@ docker port hygieia-ui
 ```
 
 ## How to setup test data
-###1. Setup GIT -  by configuring it to point to the github master branch for Hygieia
+### 1. Setup GIT -  by configuring it to point to the github master branch for Hygieia
 	a. In the SCM panel, select 'git'
 	b. Enter the URL: 'https://github.com/capitalone/Hygieia.git' (without the quotes)
 	c. Set the branch to 'master' (without the quotes)
 	ote: For this to work you will need to have set your credentials on the ID that the collectors is running under, the best way to do this is first clone the repo to set your credentials.
 
-###2. Setup Sonar -  by running a test instance of sonar
+### 2. Setup Sonar -  by running a test instance of sonar
 	a. docker-compose -f test-servers/sonar/sonar.yml up -d
 	b. Fill it with data from the Hygieia project
 mvn sonar:sonar -Dsonar.host.url=http://$(docker-machine ip default):9000 -Dsonar.jdbc.url="jdbc:h2:tcp://$(docker-machine ip default)/sonar"
 	c. You can now go in and configure the quality panel in the UI.
 
-###3. Setup Jenkins w/cucumber output - by starting a test jenkins master
+### 3. Setup Jenkins w/cucumber output - by starting a test jenkins master
 	a. docker-compose -f test-servers/jenkins/jenkins.yml up -d
 	b. Run the job: http://192.168.99.100:9100/job/Hygieia_Example_Job/build
 	c. Configure the Jenkins Build and Jenkins Cucumber panels using this jobs output.

--- a/core/README.md
+++ b/core/README.md
@@ -1,4 +1,4 @@
 
-##Hygieia℠ Common
+## Hygieia℠ Common
 ======
 Common library for all collectors and rest controllers in the DevOps Dashboard.

--- a/core/create_collector.md
+++ b/core/create_collector.md
@@ -84,7 +84,7 @@ Create CollectorTask
 Create a class that extends the abstract CollectorTask and implement the required abstract methods.
 
 
-###getCollector() Method
+### getCollector() Method
 --------------------------------------
 
 The getCollector method should return a prototypical instance of your Collector subclass (eg PivotalTrackerCollector). This
@@ -92,30 +92,30 @@ method is only used the very first time your collector runs so that your collect
 collection in MongoDB.
 
 
-###getCollectorRepository() Method
+### getCollectorRepository() Method
 --------------------------------------
 
 This method should return a reference to your custom collector repository.
 
-###getCron() Method
+### getCron() Method
 --------------------------------------
 
 This method should return the cron expression to schedule how often your collector executes.
 
-###collect() Method
+### collect() Method
 --------------------------------------
 
 The collect method holds the business logic for your collector. This method is called on a schedule based on the value you
 provide from the getCron() method..
 
 
-###Spring Singleton
+### Spring Singleton
 --------------------------------------
 
 The CollectorTask class is a Spring bean singleton. Use the constructor to inject any Spring beans that are required to
 execute the logic of your collector (eg MongDB repositories such as FeatureRepository).
 
-###Example
+### Example
 --------------------------------------
 
     package com.capitalone.dashboard.collector;
@@ -207,7 +207,7 @@ the Spring Boot [documentation](http://docs.spring.io/spring-boot/docs/current-S
 for information about sourcing this properties file.
 
 
-###Sample application.properties file
+### Sample application.properties file
 --------------------------------------
 
     #Database Name

--- a/features.md
+++ b/features.md
@@ -1,6 +1,6 @@
-##Hygieia New Features Released##
+## Hygieia New Features Released ##
 
-###Basic Http Monitoring###
+### Basic Http Monitoring ###
  Hygieia Monitoring widget now supports basic http monitoring.
  
  

--- a/hygieia-jenkins-plugin/README.md
+++ b/hygieia-jenkins-plugin/README.md
@@ -22,7 +22,7 @@ Clone Hygieia root, `cd` to `core`, and do `mvn clean install` before building t
 # Important
 This plugin uses the Hygieia core package. The main project is JDK 1.8 compiled, if you have Jenkins running on previous Java versions, make sure to recompile core package with that previous version and then build this Jenkins plugin.
 
-#Brief Instruction
+# Brief Instruction
 ## Jenkins 2.0 w/ pipeline 
 1. Install the plugin by using "Advanced" option in Jenkins Plugin Management option to manually upload the file from local disk.
 2. Restart jenkins.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
