### PR TITLE
Gitlab Ignore Untrusted Certs/Log Location fix

### DIFF
--- a/collectors/feature/gitlab/README.md
+++ b/collectors/feature/gitlab/README.md
@@ -70,4 +70,7 @@ gitlab.path=/gitlab/resides/here
 #We recommend creating a Gitlab account for the collector, using it's Access Token, and adding that user to teams you want to see issues for
 gitlab.apiToken=
 
+#Gitlab selfSignedCertificate (optional, defaults to false, set to true if your instance of gitlab is running on https without a trusted certificate
+gitlab.selfSignedCertificate=false
+
 ```

--- a/collectors/feature/gitlab/docker/gitlab-properties-builder.sh
+++ b/collectors/feature/gitlab/docker/gitlab-properties-builder.sh
@@ -59,6 +59,9 @@ gitlab.path=${GITLAB_PATH:-}
 #Gitlab API Token (required, must be an admin account to retrieve all teams for the instance of gitlab.  If not admin, will only retrieve teams the user belongs to)
 gitlab.apiToken=${GITLAB_API_TOKEN:-}
 
+#Gitlab selfSignedCertificate (optional, defaults to false, set to true if your instance of gitlab is running on https without a trusted certificate
+gitlab.selfSignedCertificate=${GITLAB_SELF_SIGNED_CERTIFICATE:-false}
+
 EOF
 
 echo "

--- a/collectors/feature/gitlab/src/main/resources/logback.xml
+++ b/collectors/feature/gitlab/src/main/resources/logback.xml
@@ -10,7 +10,7 @@
     <!-- <file>/prod/msp/logs/jmssp_logs/jssp-app-log</file> -->
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- rollover daily -->
-      <fileNamePattern>gitlabfeaturecollector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>logs/gitlabfeaturecollector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <timeBasedFileNamingAndTriggeringPolicy
             class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
         <!-- or whenever the file size reaches 100MB -->

--- a/collectors/scm/gitlab/src/main/java/com/capitalone/dashboard/collector/GitlabSettings.java
+++ b/collectors/scm/gitlab/src/main/java/com/capitalone/dashboard/collector/GitlabSettings.java
@@ -1,5 +1,15 @@
 package com.capitalone.dashboard.collector;
 
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.annotation.PostConstruct;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -14,6 +24,9 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties(prefix = "gitlab")
 public class GitlabSettings {
+    
+    private static final Log LOG = LogFactory.getLog(GitlabSettings.class);
+    
     private String cron;
     private String protocol;
     private String host;
@@ -86,5 +99,33 @@ public class GitlabSettings {
 	public void setSelfSignedCertificate(boolean selfSigned) {
 		this.selfSignedCertificate = selfSigned;
 	}
+	
+	@PostConstruct
+    public void trustSelfSignedCertificatesIfNecessary() {
+        if (isSelfSignedCertificate()) {
+            try {
+                final SSLContext ctx = SSLContext.getInstance("TLS");
+                final X509TrustManager tm = new X509TrustManager() {
+                    public void checkClientTrusted(final X509Certificate[] xcs, final String string)
+                            throws CertificateException {
+                    }
+
+                    public void checkServerTrusted(final X509Certificate[] xcs, final String string)
+                            throws CertificateException {
+                    }
+
+                    public X509Certificate[] getAcceptedIssuers() {
+                        X509Certificate[] n = new X509Certificate[0];
+                        return n;
+
+                    }
+                };
+                ctx.init(null, new TrustManager[] { tm }, null);
+                SSLContext.setDefault(ctx);
+            } catch (final Exception ex) {
+                LOG.error(ex.getMessage());
+            }           
+        }
+    }
 
 }

--- a/collectors/scm/gitlab/src/main/java/com/capitalone/dashboard/gitlab/DefaultGitlabGitClient.java
+++ b/collectors/scm/gitlab/src/main/java/com/capitalone/dashboard/gitlab/DefaultGitlabGitClient.java
@@ -1,18 +1,10 @@
 package com.capitalone.dashboard.gitlab;
 
 import java.net.URI;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
-
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -33,8 +25,6 @@ import com.capitalone.dashboard.util.Supplier;
 
 @Component
 public class DefaultGitlabGitClient implements  GitlabGitClient {
-
-    private static final Log LOG = LogFactory.getLog(DefaultGitlabGitClient.class);
 
     //Gitlab max results per page. Reduces amount of network calls.
     private static final int RESULTS_PER_PAGE = 100;
@@ -81,36 +71,9 @@ public class DefaultGitlabGitClient implements  GitlabGitClient {
     }
 
 	private ResponseEntity<GitlabCommit[]> makeRestCall(URI url, String apiToken) {
-		if(gitlabSettings.isSelfSignedCertificate()) {
-			trustSelfSignedSSL();
-		}
 		HttpHeaders headers = new HttpHeaders();
 		headers.add("PRIVATE-TOKEN", apiToken);
 		return restOperations.exchange(url, HttpMethod.GET, new HttpEntity<>(headers), GitlabCommit[].class);
 	}
 
-	private void trustSelfSignedSSL() {
-		try {
-			final SSLContext ctx = SSLContext.getInstance("TLS");
-			final X509TrustManager tm = new X509TrustManager() {
-				public void checkClientTrusted(final X509Certificate[] xcs, final String string)
-						throws CertificateException {
-				}
-
-				public void checkServerTrusted(final X509Certificate[] xcs, final String string)
-						throws CertificateException {
-				}
-
-				public X509Certificate[] getAcceptedIssuers() {
-					X509Certificate[] n = new X509Certificate[0];
-					return n;
-
-				}
-			};
-			ctx.init(null, new TrustManager[] { tm }, null);
-			SSLContext.setDefault(ctx);
-		} catch (final Exception ex) {
-			LOG.error(ex.getMessage());
-		}
-	}
 }


### PR DESCRIPTION
Updated the feature collector to function like the scm collector in being able to trust self signed certificates.  I also changed the scm collector to only set the property once, instead of on every request.  There is also a small logging file fix that puts the log files in a log folder like the other collectors. 