### PR TITLE
(Performance Fix) Change deploy widget to use uib-typeahead

### DIFF
--- a/UI/src/components/widgets/deploy/config.html
+++ b/UI/src/components/widgets/deploy/config.html
@@ -3,29 +3,22 @@
           ng-submit="deployConfig.submit(configForm.$valid,deployConfig.deployJob)" novalidate="novalidate">
         <form-group input="deployJob" errors="{required:'Please select your application'}">
 
-            <!--<select name="deployJob"
-                    class="form-control"
-                    ng-model="deployConfig.deployJob"
-                    ng-options="job.name for job in deployConfig.deployJobs | orderBy: 'name' track by job.value"
-                    ng-disabled="deployConfig.jobDropdownDisabled"
-                    required>
-                <option value="">{{deployConfig.jobDropdownPlaceholder}}</option>
-            </select>-->
-
-            <ui-select id="deployJob" ng-model="deployConfig.deployJob" theme="bootstrap"
-                       ng-disabled="deployConfig.jobDropdownDisabled" required>
-                <ui-select-match placeholder={{deployConfig.jobDropdownPlaceholder}}>{{$select.selected.name}}
-                </ui-select-match>
-                <ui-select-choices group-by="'group'"
-                        repeat="job in (deployConfig.deployJobs| orderBy: 'name' | filter: $select.search) track by job.value">
-                    <div ng-bind-html="job.name | highlight: $select.search"></div>
-                </ui-select-choices>
-                <ui-select-no-choice>
-                    No deployment job was found
-                </ui-select-no-choice>
-            </ui-select>
-            
-        </form-group>
+	    <input
+			type="text" name="collectorItemId" class="form-control"
+			placeholder="Search for a deployment application"
+			ng-model="deployConfig.deployJob"
+			uib-typeahead="job as job.name for job in getDeploymentJobs($viewValue)"
+			typeahead-focus 
+			typeahead-template-url="deploymentsUrlTemplate.html"
+			typeahead-min-length="0" 
+			typeahead-wait-ms="250" 
+			autocomplete="off"
+			typeahead-no-results="noResults" 
+			required>
+	
+		<div class="form-control" ng-show="noResults">
+			No Results Found
+		</div>
         
         <form-group input="ignoreRegex" errors="{validregex:'Please enter a valid Regular Expression'}">
 	
@@ -40,7 +33,7 @@
 	    </form-group>
 
         <div class="form-group checkbox">
-            <label>
+            <label title="If true deployments with the same name and ID that processed in different servers will grouped together">
                 <input type="checkbox" name="aggregateServers" ng-model="deployConfig.aggregateServers" ng-change="reload()">
                 Aggregate Servers
             </label>
@@ -61,3 +54,8 @@
         </div>
     </form>
 </widget-modal>
+<script type="text/ng-template" id="deploymentsUrlTemplate.html">
+	<a title={{match.model.group}}>
+		<span ng-bind-html="match.model.name | uibTypeaheadHighlight:query"/> 
+	</a>
+</script>

--- a/UI/src/components/widgets/deploy/config.js
+++ b/UI/src/components/widgets/deploy/config.js
@@ -5,9 +5,9 @@
         .module(HygieiaConfig.module)
         .controller('deployConfigController', deployConfigController);
 
-    deployConfigController.$inject = ['modalData', 'collectorData', '$uibModalInstance', '$q', '$scope'];
+    deployConfigController.$inject = ['modalData', 'collectorData', '$uibModalInstance', '$scope'];
   
-    function deployConfigController(modalData, collectorData, $uibModalInstance, $q, $scope) {
+    function deployConfigController(modalData, collectorData, $uibModalInstance, $scope) {
 
         /*jshint validthis:true */
         var ctrl = this;
@@ -16,10 +16,9 @@
 
         // public variables
         // ctrl.deployJob;
-        ctrl.deployJobs = [ ];
-        ctrl.jobDropdownDisabled = true;
-        ctrl.jobDropdownPlaceholder = 'Loading...';
         ctrl.submitted = false;
+        
+        // When true this makes it so applications with the same id and same name that are on different servers are treated as the same entity
         ctrl.aggregateServers = false;
         ctrl.currentData = null;
         // set values from config
@@ -36,89 +35,110 @@
 
         // public methods
         ctrl.submit = submit;
-
-        $q.all([collectorData.itemsByType('deployment')]).then(processResponse);
         
-        function processResponse(dataA) {
-        	var data = dataA[0];
-        	ctrl.currentData = dataA;
+        $scope.getDeploymentJobs = function (filter) {
+        	return getDeploymentJobsRecursive([], filter, null, 0).then(processResponse);
+        }
+        
+        loadSavedDeploymentJob();
+        
+        /*
+         * Obtains deployment jobs using recursion when necessary. 
+         * 
+         * It is necessary to make additional calls when 'aggregateServers' is true since we need all like applications on different servers 
+         * to be available when saving our data. To do this we compare the last item in the list from our first paged call to all subsequent data.
+         * If the application name and id is the same then we keep the data in our list. Once we encounter data that is different we can cease recurision
+         * since the calls are sorted.
+         * 
+         * Example:
+         * Suppose a size of 3 is used with aggregate servers and our first REST call returns the following:
+         *   Deployment A (http://deploy.instance1.com)
+         *   Deployment A (http://deploy.instance2.com)
+         *   Deployment B (http://deploy.instance1.com)
+         *   
+         * We need to make an additional rest call to see if there are any more 'Deployment B' jobs. Suppose the second REST call returns the following:
+         *   Deployment B (http://deploy.instance2.com)
+         *   Deployment B (http://deploy.instance3.com)
+         *   Deployment C (http://deploy.instance1.com)
+         *   
+         * We will keep the Deployment B's returned from the REST call and ignore everything that comes after it. Since the last item in this list is different
+         * than the name + id (not shown) for our original REST call we cease searching for more items.
+         */
+        function getDeploymentJobsRecursive(arr, filter, nameAndIdToCheck, pageNumber) {
+        	return collectorData.itemsByType('deployment', {"search": filter, "size": 20, "sort": "description", "page": pageNumber}).then(function (response){
+        		if (response.length > 0) {
+        			arr.push.apply(arr, _(response).filter(function(d) {
+    					return nameAndIdToCheck === null || nameAndIdToCheck === d.options.applicationName + "#" + d.options.applicationId;
+    				}).value());
+        		}
+        		
+        		if (ctrl.aggregateServers && response.length > 0) {
+        			// The last item could have additional deployments with the same name but different servers
+        			var lastItem = response.slice(-1)[0];
+        			
+        			var checkKey = lastItem.options.applicationName  + "#" + lastItem.options.applicationId;
+        			if (nameAndIdToCheck === null || checkKey === nameAndIdToCheck) {
+        				// We should check to see if the next page has the same item for our grouping
+        				
+        				return getDeploymentJobsRecursive(arr, filter, checkKey, pageNumber + 1);
+        			}
+        		}
+        		return arr;
+        	});
+        }
+        
+        function processResponse(data) {
+        	ctrl.currentData = data;
         	
+            // If true we ignore instanceUrls and treat applications with the same id spread across 
+            // multiple servers as equivalent. This allows us to fully track an application across
+            // all environments in the case that servers are split by function (prod deployment servers
+            // vs nonprod deployment servers)
+            var multiServerEquality = ctrl.aggregateServers;
 
-            var worker = {
-                getDeploys: getDeploys
-            };
+            var dataGrouped = _(data)
+                .groupBy(function(d) { return (!multiServerEquality ? d.options.instanceUrl + "#" : "" ) + d.options.applicationName + d.options.applicationId; })
+                .map(function(d) { return d; });
+
+            var deploys = _(dataGrouped).map(function(deploys, idx) {
+            	var firstDeploy = deploys[0];
+            	
+            	var name = firstDeploy.options.applicationName;
+            	var group = "";
+            	var ids = new Array(deploys.length);
+            	for (var i = 0; i < deploys.length; ++i) {
+            		var deploy = deploys[i];
+            		
+            		ids[i] = deploy.id;
+            		
+            		if (i > 0) {
+            			group += '\n';
+            		}
+            		group += ((deploy.niceName != null) && (deploy.niceName != "") ? deploy.niceName : deploy.collector.name) + " (" + deploy.options.instanceUrl + ")";
+                }
+            	
+                return {
+                    value: ids,
+                    name: name,
+                    group: group
+                };
+            }).value();
             
-            function getDeploys(data, currentCollectorItemIds, cb) {
-                var selectedIndex = null;
-                
-                // If true we ignore instanceUrls and treat applications with the same id spread across 
-                // multiple servers as equivalent. This allows us to fully track an application across
-                // all environments in the case that servers are split by function (prod deployment servers
-                // vs nonprod deployment servers)
-                var multiServerEquality = ctrl.aggregateServers;
-
-                var dataGrouped = _(data)
-                    .groupBy(function(d) { return (!multiServerEquality ? d.options.instanceUrl + "#" : "" ) + d.options.applicationName + d.options.applicationId; })
-                    .map(function(d) { return d; });
-
-                var deploys = _(dataGrouped).map(function(deploys, idx) {
-                	var firstDeploy = deploys[0];
-                	
-                	var name = "";
-                	var group = "";
-                	var ids = new Array(deploys.length);
-                	for (var i = 0; i < deploys.length; ++i) {
-                		var deploy = deploys[i];
-                		
-                		ids[i] = deploy.id;
-                		
-                		if (_.contains(currentCollectorItemIds, deploy.id)) {
-                            selectedIndex = idx;
-                        }
-                		
-                		if (i > 0) {
-                			name += ', ';
-                		}
-                		name += ((deploy.niceName != null) && (deploy.niceName != "") ? deploy.niceName : deploy.collector.name);
-                    }
-                	
-                	group = name;
-                	name += '-' + firstDeploy.options.applicationName;
-                	
-                    return {
-                        value: ids,
-                        name: name,
-                        group: group
-                    };
-                }).value();
-
-                cb({
-                    deploys: deploys,
-                    selectedIndex: selectedIndex
-                });
+            return deploys;
+        }
+        
+        // method implementations
+        function loadSavedDeploymentJob(){
+        	var deployCollector = modalData.dashboard.application.components[0].collectorItems.Deployment,
+            savedCollectorDeploymentJob = deployCollector ? deployCollector[0].description : null;
+            if(savedCollectorDeploymentJob) { 
+            	$scope.getDeploymentJobs(savedCollectorDeploymentJob).then(getDeploysCallback) 
             }
-
-            var deployCollectorItems = modalData.dashboard.application.components[0].collectorItems.Deployment;
-            var selectedIds = [];
-            if (deployCollectorItems) {
-            	selectedIds = _.map(deployCollectorItems, function(ci) { return ci.id } )
-            }
-            
-            worker.getDeploys(data, selectedIds, getDeploysCallback);
         }
 
         function getDeploysCallback(data) {
-            //$scope.$apply(function() {
-                ctrl.jobDropdownDisabled = false;
-                ctrl.jobDropdownPlaceholder = 'Select your application';
-                ctrl.deployJobs = data.deploys;
-
-                if(data.selectedIndex !== null) {
-                    ctrl.deployJob = data.deploys[data.selectedIndex];
-                }
-            //});
+        	ctrl.deployJob = data[0];
         }
-
 
         function submit(valid, job) {
             ctrl.submitted = true;

--- a/collectors/deploy/xldeploy/src/main/java/com/capitalone/dashboard/collector/DefaultXLDeployClient.java
+++ b/collectors/deploy/xldeploy/src/main/java/com/capitalone/dashboard/collector/DefaultXLDeployClient.java
@@ -114,6 +114,7 @@ public class DefaultXLDeployClient implements XLDeployClient {
 	}
 	
 	@Override
+	@SuppressWarnings({"PMD.NPathComplexity"})
 	public List<XLDeployApplicationHistoryItem> getApplicationHistory(List<XLDeployApplication> applications, Date startDate, Date endDate) {
 		if (applications == null || applications.isEmpty()) {
 			return Collections.<XLDeployApplicationHistoryItem>emptyList();

--- a/collectors/deploy/xldeploy/src/main/java/com/capitalone/dashboard/collector/DefaultXLDeployClient.java
+++ b/collectors/deploy/xldeploy/src/main/java/com/capitalone/dashboard/collector/DefaultXLDeployClient.java
@@ -148,7 +148,14 @@ public class DefaultXLDeployClient implements XLDeployClient {
 				
 				XLDeployApplicationHistoryItem historyItem = new XLDeployApplicationHistoryItem();
 				historyItem.setEnvironmentName(deploymentData.get("environment"));
-				historyItem.setDeploymentPackage(deploymentData.get("package"));
+				
+				String pkg = deploymentData.get("package");
+				
+				// updates seem to give both packages in play separated by a comma
+				if (pkg != null && pkg.indexOf(',') >= 0) {
+					pkg = pkg.substring(0, pkg.indexOf(','));
+				}
+				historyItem.setDeploymentPackage(pkg);
 				historyItem.setEnvironmentId(deploymentData.get("environmentId"));
 				
 				try {

--- a/collectors/deploy/xldeploy/src/test/java/com/capitalone/dashboard/collector/DefaultXLDeployClientTest.java
+++ b/collectors/deploy/xldeploy/src/test/java/com/capitalone/dashboard/collector/DefaultXLDeployClientTest.java
@@ -106,7 +106,7 @@ public class DefaultXLDeployClientTest {
         
         assertThat(((String)entCaptor.getValue().getBody()).replaceAll("(\r|\n|\t)", ""), is(appHistPostXml.replaceAll("(\r|\n|\t)", "")));
         
-        assertThat(hist.size(), is(2));
+        assertThat(hist.size(), is(3));
         assertThat(hist.get(0).getEnvironmentName(), is("QA01"));
         assertThat(hist.get(0).getDeploymentPackage(), is("Helloworld/helloworld-v1.0.0"));
         assertThat(hist.get(0).getEnvironmentId(), is("Environments/qa/QA01"));
@@ -119,6 +119,9 @@ public class DefaultXLDeployClientTest {
         
         assertThat(hist.get(1).getEnvironmentName(), is("Production"));
         assertThat(hist.get(1).getDeploymentPackage(), is("Helloworld/helloworld-v1.0.0"));
+        
+        assertThat(hist.get(2).getEnvironmentName(), is("Production"));
+        assertThat(hist.get(2).getDeploymentPackage(), is("Helloworld/helloworld-v1.0.1"));
     }
     
     private String getXml(String fileName) throws IOException {

--- a/collectors/deploy/xldeploy/src/test/resources/com/capitalone/dashboard/collector/applicationHistory1.xml
+++ b/collectors/deploy/xldeploy/src/test/resources/com/capitalone/dashboard/collector/applicationHistory1.xml
@@ -87,4 +87,48 @@
          </item>
       </values>
    </lines>
+   <lines>
+      <values>
+         <item>
+            <key>environment</key>
+            <value xsi:type="xs:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">Production</value>
+         </item>
+         <item>
+            <key>package</key>
+            <value xsi:type="xs:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">Helloworld/helloworld-v1.0.1, Helloworld/helloworld-v1.0.0</value>
+         </item>
+         <item>
+            <key>environmentId</key>
+            <value xsi:type="xs:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">Environments/prod/Production</value>
+         </item>
+         <item>
+            <key>completionDate</key>
+            <value xsi:type="xs:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">2016-04-12T15:04:24.567+0000</value>
+         </item>
+         <item>
+            <key>environmentIdWithoutRoot</key>
+            <value xsi:type="xs:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">prod/Production</value>
+         </item>
+         <item>
+            <key>type</key>
+            <value xsi:type="xs:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">Update</value>
+         </item>
+         <item>
+            <key>user</key>
+            <value xsi:type="xs:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">admin</value>
+         </item>
+         <item>
+            <key>taskId</key>
+            <value xsi:type="xs:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">aaaafc80-eedf-410e-bc43-4a0c3fdd4nnn</value>
+         </item>
+         <item>
+            <key>startDate</key>
+            <value xsi:type="xs:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">2016-04-12T15:04:24.567+0000</value>
+         </item>
+         <item>
+            <key>status</key>
+            <value xsi:type="xs:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">DONE</value>
+         </item>
+      </values>
+   </lines>
 </report>


### PR DESCRIPTION
This widget was skipped when changes were made to other widgets to convert them to use the uib-typeahead directive (#1049). This PR changes the deploy widget to use the typeahead mechanism. It works with or without the "aggregateServer" option. I also fixed an XLD bug while in here.

When aggregate servers is on it obtains data using the following algorithm:
```
        /*
         * Obtains deployment jobs using recursion when necessary. 
         * 
         * It is necessary to make additional calls when 'aggregateServers' is true since we need all like applications on different servers 
         * to be available when saving our data. To do this we compare the last item in the list from our first paged call to all subsequent data.
         * If the application name and id is the same then we keep the data in our list. Once we encounter data that is different we can cease recurision
         * since the calls are sorted.
         * 
         * Example:
         * Suppose a size of 3 is used with aggregate servers and our first REST call returns the following:
         *   Deployment A (http://deploy.instance1.com)
         *   Deployment A (http://deploy.instance2.com)
         *   Deployment B (http://deploy.instance1.com)
         *   
         * We need to make an additional rest call to see if there are any more 'Deployment B' jobs. Suppose the second REST call returns the following:
         *   Deployment B (http://deploy.instance2.com)
         *   Deployment B (http://deploy.instance3.com)
         *   Deployment C (http://deploy.instance1.com)
         *   
         * We will keep the Deployment B's returned from the REST call and ignore everything that comes after it. Since the last item in this list is different
         * than the name + id (not shown) for our original REST call we cease searching for more items.
         */
```