### PR TITLE
Active Directory Url Fix

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -50,6 +50,8 @@ auth.ldapUserDnPattern=[uid={0},OU=Users,dc=your,dc=company,dc=com]
 auth.adDomain=[company.com]
 # This will be your root dn
 auth.adRootDn=[dc=your,dc=company,dc=com]
+# This will be your active directory url (required for AD)
+auth.adUrl=[Need an example]
 
 monitor.proxy.host=[hostname of proxy server]
 monitor.proxy.type=[http|socks|direct]

--- a/api/docker/properties-builder.sh
+++ b/api/docker/properties-builder.sh
@@ -50,6 +50,8 @@ auth.ldapUserDnPattern=${AUTH_LDAP_USER_DN_PATTERN:-}
 auth.adDomain=${AUTH_AD_DOMAIN:-}
 # This will be your root dn
 auth.adRootDn=${AUTH_AD_ROOT_DN:-}
+# This is your active directory url
+auth.adUrl=${AUTH_AD_URL:-}
 
 #Monitor Widget proxy credentials
 monitor.proxy.username=${MONITOR_PROXY_USERNAME:-}

--- a/api/src/main/java/com/capitalone/dashboard/auth/AuthProperties.java
+++ b/api/src/main/java/com/capitalone/dashboard/auth/AuthProperties.java
@@ -23,6 +23,7 @@ public class AuthProperties {
 	private String ldapServerUrl;
 	private String adDomain;
 	private String adRootDn;
+	private String adUrl;
 	
 	public void setExpirationTime(Long expirationTime) {
 		this.expirationTime = expirationTime;
@@ -71,6 +72,14 @@ public class AuthProperties {
 	public void setAdRootDn(String adRootDn) {
 		this.adRootDn = adRootDn;
 	}
+	
+    public String getAdUrl() {
+        return adUrl;
+    }
+
+    public void setAdUrl(String adUrl) {
+        this.adUrl = adUrl;
+    }
 
 	@PostConstruct
 	public void applyDefaultsIfNeeded() {


### PR DESCRIPTION
Resolves #1385, #1383 .  Added a property for active directory url to make it more explicit as to what you are configuring.  The API also now handles null properties for the url so it can start even if not provided.  Would appreciate if someone could run this with active directory to make sure it works as intended.   