### PR TITLE
Fix create dashboard button showing up when not logged in

### DIFF
--- a/UI/src/app/dashboard/views/site.html
+++ b/UI/src/app/dashboard/views/site.html
@@ -37,7 +37,7 @@
                 <div class="row gap">
                     <div class="col-sm-4 col-sm-push-8 text-center">
                         <div>
-                            <div class="create-dashboard-button btn btn-default btn-wide-2x" ng-click="ctrl.createDashboard()">
+                            <div class="create-dashboard-button btn btn-default btn-wide-2x" ng-click="ctrl.createDashboard()" ng-show="ctrl.showAuthentication">
                                 <span class="fa fa-stack fa-lg">
                                     <span class="fa-circle-thin fa-stack-2x"></span>
                                     <span class="fa-plus fa-stack-1x"></span>


### PR DESCRIPTION
Looks like this got lost in a merge conflict.  Just hides the create button if you aren't logged in.