### PR TITLE
UI: comments and notes on how to use custom port number for API server

### DIFF
--- a/UI/README.md
+++ b/UI/README.md
@@ -90,6 +90,12 @@ mvn clean package -pl UI docker:build
 ```bash
 docker run -t -p 8088:80 --link hygieia-api -i hygieia-ui:latest
 ```
+### API server running on a custom port
+If the API server is running on a port other than the default (`8080`) then modify `UI/gulpfile.js` to include the custom port:
+```
+// Using port 8888 for the API server instead of the default (8080)
+var proxyTarget = config.api || 'http://localhost:8888';
+```
 
 ### API check
 

--- a/UI/gulpfile.js
+++ b/UI/gulpfile.js
@@ -98,7 +98,7 @@ function server(ghostMode) {
   ghostMode = typeof ghostMode == 'undefined' ? false : true
   return function () {
       /*
-       * Location of your backend server
+       * Location of your backend (API) server--default port 8080
        */
       var proxyTarget = config.api || 'http://localhost:8080';
 


### PR DESCRIPTION
How to modify Hygieia configuration to use a custom port number for the API server, instead of the default (`8080`). This pull request includes notes on how to modify `UI/gulpfile.js` to support custom API port.