### PR TITLE
Renamed Splunk Logging Components

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -31,8 +31,12 @@ dbreplicaset=[false if you are not using MongoDB replicaset]
 dbhostport=[host1:port1,host2:port2,host3:port3]
 server.contextPath=[Web Context path if any]
 server.port=[Web server port - default is 8080]
+
+# Enable default application logging
 logRequest=false
-logSplunkRequest=false
+
+# Enable logging in a key=value format
+logRequestKeyValue=false
 corsEnabled=false
 corsWhitelist=http://domain1.com:port,http://domain2.com:port
 version.number=@application.version.number@

--- a/api/src/main/java/com/capitalone/dashboard/config/LoggingConfig.java
+++ b/api/src/main/java/com/capitalone/dashboard/config/LoggingConfig.java
@@ -5,17 +5,17 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 import com.capitalone.dashboard.logging.DatabaseLoggingCondition;
+import com.capitalone.dashboard.logging.KeyValueLoggingCondition;
+import com.capitalone.dashboard.logging.KeyValueLoggingFilter;
 import com.capitalone.dashboard.logging.LoggingFilter;
-import com.capitalone.dashboard.logging.SplunkConnectionLoggingFilter;
-import com.capitalone.dashboard.logging.SplunkLoggingCondition;
 
 @Configuration
 public class LoggingConfig {
     
     @Bean
-    @Conditional(SplunkLoggingCondition.class)
-    public SplunkConnectionLoggingFilter splunkConnectionLoggingFilter() {
-        return new SplunkConnectionLoggingFilter();
+    @Conditional(KeyValueLoggingCondition.class)
+    public KeyValueLoggingFilter splunkConnectionLoggingFilter() {
+        return new KeyValueLoggingFilter();
     }
     
     @Bean

--- a/api/src/main/java/com/capitalone/dashboard/logging/KeyValueLoggingCondition.java
+++ b/api/src/main/java/com/capitalone/dashboard/logging/KeyValueLoggingCondition.java
@@ -4,14 +4,14 @@ import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
-public class SplunkLoggingCondition implements Condition {
+public class KeyValueLoggingCondition implements Condition {
 
-    protected static final String LOG_SPLUNK_REQUEST = "logSplunkRequest";
+    protected static final String LOG_REQUEST_KEY_VALUE = "logRequestKeyValue";
 
     @Override
     public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
-        String logSplunkRequest = context.getEnvironment().getProperty(LOG_SPLUNK_REQUEST);
-        return logSplunkRequest != null && Boolean.parseBoolean(logSplunkRequest);
+        String logRequestKeyValue = context.getEnvironment().getProperty(LOG_REQUEST_KEY_VALUE);
+        return logRequestKeyValue != null && Boolean.parseBoolean(logRequestKeyValue);
     }
 
 }

--- a/api/src/main/java/com/capitalone/dashboard/logging/KeyValueLoggingFilter.java
+++ b/api/src/main/java/com/capitalone/dashboard/logging/KeyValueLoggingFilter.java
@@ -20,9 +20,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import com.capitalone.dashboard.model.SplunkLog;
+import com.capitalone.dashboard.model.KeyValueLog;
 
-public class SplunkConnectionLoggingFilter implements Filter {
+public class KeyValueLoggingFilter implements Filter {
     
     protected static final String USER_AUTHORITIES = "USER_AUTHORITIES";
     protected static final String USER_DETAILS = "USER_DETAILS";
@@ -35,7 +35,7 @@ public class SplunkConnectionLoggingFilter implements Filter {
     protected static final String APPLICATION_NAME = "APPLICATION_NAME";
     protected static final String APPLICATION_VERSION = "APPLICATION_VERSION";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SplunkConnectionLoggingFilter.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(KeyValueLoggingFilter.class);
     
     @Value("${application.name}")
     private String appName;
@@ -53,9 +53,9 @@ public class SplunkConnectionLoggingFilter implements Filter {
         LOGGER.info(getLogEntry(requestWrapper, responseWrapper).toString());
     }
 
-    private SplunkLog getLogEntry(HttpServletRequest request, HttpServletResponse response) {
+    private KeyValueLog getLogEntry(HttpServletRequest request, HttpServletResponse response) {
         
-        SplunkLog log = new SplunkLog();
+        KeyValueLog log = new KeyValueLog();
         log.with(REMOTE_ADDRESS, request.getRemoteAddr())
             .with(APPLICATION_NAME, appName)
             .with(APPLICATION_VERSION, version)

--- a/api/src/test/java/com/capitalone/dashboard/logging/KeyValueLoggingConditionTest.java
+++ b/api/src/test/java/com/capitalone/dashboard/logging/KeyValueLoggingConditionTest.java
@@ -14,7 +14,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 @RunWith(MockitoJUnitRunner.class)
-public class SplunkLoggingConditionTest {
+public class KeyValueLoggingConditionTest {
 
     @Mock
     private ConditionContext context;
@@ -26,34 +26,34 @@ public class SplunkLoggingConditionTest {
     private AnnotatedTypeMetadata metadata;
     
     @InjectMocks
-    private SplunkLoggingCondition condition;
+    private KeyValueLoggingCondition condition;
     
     @Test
     public void shouldBeTrueWhenPropertyTrue() {
-        SplunkLoggingCondition condition = new SplunkLoggingCondition();
+    	KeyValueLoggingCondition condition = new KeyValueLoggingCondition();
         
         when(context.getEnvironment()).thenReturn(environment);
-        when(environment.getProperty(SplunkLoggingCondition.LOG_SPLUNK_REQUEST)).thenReturn("true");
+        when(environment.getProperty(KeyValueLoggingCondition.LOG_REQUEST_KEY_VALUE)).thenReturn("true");
         
         assertTrue(condition.matches(context, metadata));
     }
     
     @Test
     public void shouldBeFalseWhenPropertyFalse() {
-        SplunkLoggingCondition condition = new SplunkLoggingCondition();
+    	KeyValueLoggingCondition condition = new KeyValueLoggingCondition();
         
         when(context.getEnvironment()).thenReturn(environment);
-        when(environment.getProperty(SplunkLoggingCondition.LOG_SPLUNK_REQUEST)).thenReturn("false");
+        when(environment.getProperty(KeyValueLoggingCondition.LOG_REQUEST_KEY_VALUE)).thenReturn("false");
         
         assertFalse(condition.matches(context, metadata));
     }
     
     @Test
     public void shouldBeFalseWhenPropertyNull() {
-        SplunkLoggingCondition condition = new SplunkLoggingCondition();
+    	KeyValueLoggingCondition condition = new KeyValueLoggingCondition();
         
         when(context.getEnvironment()).thenReturn(environment);
-        when(environment.getProperty(SplunkLoggingCondition.LOG_SPLUNK_REQUEST)).thenReturn(null);
+        when(environment.getProperty(KeyValueLoggingCondition.LOG_REQUEST_KEY_VALUE)).thenReturn(null);
         
         assertFalse(condition.matches(context, metadata));
     }

--- a/api/src/test/java/com/capitalone/dashboard/logging/KeyValueLoggingFilterTest.java
+++ b/api/src/test/java/com/capitalone/dashboard/logging/KeyValueLoggingFilterTest.java
@@ -37,7 +37,7 @@ import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 
 @RunWith(MockitoJUnitRunner.class)
-public class SplunkConnectionLoggingFilterTest {
+public class KeyValueLoggingFilterTest {
     
     @Mock
     private HttpServletRequest request;
@@ -64,14 +64,14 @@ public class SplunkConnectionLoggingFilterTest {
     private String requestMethod = "POST";
     private int statusCode = 200;
     
-    SplunkConnectionLoggingFilter filter;
+    KeyValueLoggingFilter filter;
 
     @Before
     public void setup() {
         Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         logger.addAppender(appender);
         
-        filter = new SplunkConnectionLoggingFilter();
+        filter = new KeyValueLoggingFilter();
         
         ReflectionTestUtils.setField(filter, "appName", appName);
         ReflectionTestUtils.setField(filter, "version", appVersion);
@@ -97,12 +97,12 @@ public class SplunkConnectionLoggingFilterTest {
         LoggingEvent loggingEvent = logCaptor.getValue();
         
         assertEquals(Level.INFO, loggingEvent.getLevel());
-        assertTrue(verifyLogContains(loggingEvent, SplunkConnectionLoggingFilter.REMOTE_ADDRESS, remoteAddress));
-        assertTrue(verifyLogContains(loggingEvent, SplunkConnectionLoggingFilter.APPLICATION_NAME, appName));
-        assertTrue(verifyLogContains(loggingEvent, SplunkConnectionLoggingFilter.APPLICATION_VERSION, appVersion));
-        assertTrue(verifyLogContains(loggingEvent, SplunkConnectionLoggingFilter.REQUEST_URL, requestUrl));
-        assertTrue(verifyLogContains(loggingEvent, SplunkConnectionLoggingFilter.REQUEST_METHOD, requestMethod));
-        assertTrue(verifyLogContains(loggingEvent, SplunkConnectionLoggingFilter.STATUS_CODE, statusCode));
+        assertTrue(verifyLogContains(loggingEvent, KeyValueLoggingFilter.REMOTE_ADDRESS, remoteAddress));
+        assertTrue(verifyLogContains(loggingEvent, KeyValueLoggingFilter.APPLICATION_NAME, appName));
+        assertTrue(verifyLogContains(loggingEvent, KeyValueLoggingFilter.APPLICATION_VERSION, appVersion));
+        assertTrue(verifyLogContains(loggingEvent, KeyValueLoggingFilter.REQUEST_URL, requestUrl));
+        assertTrue(verifyLogContains(loggingEvent, KeyValueLoggingFilter.REQUEST_METHOD, requestMethod));
+        assertTrue(verifyLogContains(loggingEvent, KeyValueLoggingFilter.STATUS_CODE, statusCode));
     }
     
     @Test
@@ -124,10 +124,10 @@ public class SplunkConnectionLoggingFilterTest {
         verify(appender).doAppend(logCaptor.capture());
         LoggingEvent loggingEvent = logCaptor.getValue();
         
-        assertTrue(verifyLogContains(loggingEvent, SplunkConnectionLoggingFilter.SESSION_ID, sessionId));
-        assertTrue(verifyLogContains(loggingEvent, SplunkConnectionLoggingFilter.USER_NAME, principal));
-        assertTrue(verifyLogContains(loggingEvent, SplunkConnectionLoggingFilter.USER_DETAILS, userDetails));
-        assertTrue(verifyLogContains(loggingEvent, SplunkConnectionLoggingFilter.USER_AUTHORITIES, "[ROLE_ADMIN]"));
+        assertTrue(verifyLogContains(loggingEvent, KeyValueLoggingFilter.SESSION_ID, sessionId));
+        assertTrue(verifyLogContains(loggingEvent, KeyValueLoggingFilter.USER_NAME, principal));
+        assertTrue(verifyLogContains(loggingEvent, KeyValueLoggingFilter.USER_DETAILS, userDetails));
+        assertTrue(verifyLogContains(loggingEvent, KeyValueLoggingFilter.USER_AUTHORITIES, "[ROLE_ADMIN]"));
     }
 
     private boolean verifyLogContains(LoggingEvent loggingEvent, String field, Object value) {

--- a/core/src/main/java/com/capitalone/dashboard/model/KeyValueLog.java
+++ b/core/src/main/java/com/capitalone/dashboard/model/KeyValueLog.java
@@ -4,7 +4,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
-public class SplunkLog {
+public class KeyValueLog {
     
     private static final char SEPERATOR = ' ';
     private static final char EQUALS = '=';
@@ -14,7 +14,7 @@ public class SplunkLog {
     
     private Map<String, Object> attributes = new LinkedHashMap<>();
     
-    public SplunkLog with(String key, Object value) {
+    public KeyValueLog with(String key, Object value) {
         attributes.put(key, value);
         return this;
     }


### PR DESCRIPTION
This PR merely renames the splunk logging components to something that sounds a little more generic. While using the splunk product was the inspiration behind the components, we didn't want developers to feel like they needed splunk deployed in order to log in a key-value pair style.

@rob-miller-777 