### PR TITLE
Fixes for PR1264 & new test for Delete Dashboard

### DIFF
--- a/UI-tests/README.md
+++ b/UI-tests/README.md
@@ -61,3 +61,11 @@ Since the tests were designed to run on a docker platform, **there is no data cl
 ## A note on passwords...
 
 Since this is all test data, passwords are not encrypted. The included database setup file (mongo_setup.js) has a hashed password 'password' to allow easy insertion.
+
+## Executing Tests Without Docker Setup
+
+In the UI-tests folder under project root, execute the following command. Use an existing username and password for the tests to login to the application
+
+Example:
+
+`mvn clean verify -f ./docker-pom.xml -DUITEST_EXISTING_USERNAME=hygieia_test_user -DUITEST_EXISTING_PASSWORD=password`

--- a/UI-tests/src/main/resources/stories/delete_dashboard_test.story
+++ b/UI-tests/src/main/resources/stories/delete_dashboard_test.story
@@ -1,0 +1,15 @@
+Meta:
+@dashboard
+@smoke
+
+Narrative:
+	As a software project stakeholder
+	I want to ensure that I am able delete a dashboard for my project
+	In order to clean up unwanted dashboards.
+
+
+Scenario: User deletes a dashboard
+Given I am an authorized project stakeholder
+And I am on the Hygieia home screen
+When I delete a team dashboard
+Then the dashboard 'DummyDashboard' should be deleted

--- a/UI-tests/src/test/java/com/capitalone/dashboard/uitest/definitions/DeleteDashboardDefinitions.java
+++ b/UI-tests/src/test/java/com/capitalone/dashboard/uitest/definitions/DeleteDashboardDefinitions.java
@@ -1,0 +1,26 @@
+package com.capitalone.dashboard.uitest.definitions;
+
+import net.thucydides.core.annotations.Steps;
+
+import org.jbehave.core.annotations.Named;
+import org.jbehave.core.annotations.Then;
+import org.jbehave.core.annotations.When;
+
+import com.capitalone.dashboard.uitest.steps.UserSteps;
+
+public class DeleteDashboardDefinitions {
+
+	@Steps
+	UserSteps user;
+
+	@When("I delete a team dashboard")
+	public void clickDeleteButton() {
+		user.clicks_delete_dashboard();
+	}
+	
+	@Then("the dashboard '$dashboardName' should be deleted")
+	public void currentDashboardReads(@Named("dashboardName") String dashboardName) {
+		user.should_not_see_given_dashboard(dashboardName);
+	}
+
+}

--- a/UI-tests/src/test/java/com/capitalone/dashboard/uitest/pages/HomePage.java
+++ b/UI-tests/src/test/java/com/capitalone/dashboard/uitest/pages/HomePage.java
@@ -8,9 +8,11 @@ import org.openqa.selenium.support.ui.Select;
 import net.serenitybdd.core.pages.PageObject;
 import net.thucydides.core.annotations.At;
 import net.thucydides.core.annotations.DefaultUrl;
+import java.util.List;
+import java.util.ArrayList;
 
-@DefaultUrl("https://localhost:3000/#/site")
-@At(urls={"#HOST/#/site"})
+@DefaultUrl("http://localhost:3000/#/")
+@At(urls={"#HOST/#/"})
 public class HomePage extends PageObject {
 	
 	@FindBy(className="welcome-header")
@@ -39,9 +41,12 @@ public class HomePage extends PageObject {
 	
 	@FindBy(id="filter")
 	WebElement filterByDashboardInput;
-	
-	@FindBy(css=".fa.fa-lg.fa-trash.text-danger")
+
+	@FindBy(id="deleteDashboardButton")
 	WebElement deleteDashboardButton;
+
+	@FindBy(css=".list-group-item")
+	List<WebElement> allDashboards;
 	
 	public HomePage(WebDriver driver) {
 		super(driver);
@@ -63,6 +68,10 @@ public class HomePage extends PageObject {
 		innerCreateNewDashboardButton.click();
 	}
 
+	public void clickDeleteDashboardButton() {
+		deleteDashboardButton.click();
+	}
+
 	public void setDashboardTypeDropdownMenuTo(String teamDropdownOption) {
 		Select dropdown = new Select(dashboardTypeDropdown);
 		dropdown.selectByVisibleText(teamDropdownOption);
@@ -79,6 +88,14 @@ public class HomePage extends PageObject {
 
 	public void typeInToApplicationTitleInput(String applicationTitle) {
 		applicationNameInput.sendKeys(applicationTitle);
+	}
+
+	public List<String> getAllDashboards() {
+		List<String> allDashboardNames = new ArrayList<String>();
+		for (WebElement dashboard : allDashboards) {
+			allDashboardNames.add(dashboard.getText());
+		}
+		return allDashboardNames;
 	}
 
 }

--- a/UI-tests/src/test/java/com/capitalone/dashboard/uitest/pages/LoginPage.java
+++ b/UI-tests/src/test/java/com/capitalone/dashboard/uitest/pages/LoginPage.java
@@ -8,8 +8,8 @@ import net.thucydides.core.annotations.DefaultUrl;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
-@DefaultUrl("https://localhost:3000/#/")
-@At(urls={"#HOST/#/"})
+@DefaultUrl("http://localhost:3000/#/login")
+@At(urls={"#HOST/#/login"})
 public class LoginPage extends PageObject {
 
 	@FindBy(name="username")

--- a/UI-tests/src/test/java/com/capitalone/dashboard/uitest/steps/UserSteps.java
+++ b/UI-tests/src/test/java/com/capitalone/dashboard/uitest/steps/UserSteps.java
@@ -1,6 +1,9 @@
 package com.capitalone.dashboard.uitest.steps;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.hasItem;
 import net.thucydides.core.annotations.Step;
 
 import org.apache.commons.lang3.StringUtils;
@@ -71,6 +74,11 @@ public class UserSteps {
 	@Step
 	public void clicks_delete_dashboard() {
 		homePage.clickDeleteDashboard();
+	}
+
+	@Step
+	public void should_not_see_given_dashboard(String dashboardName) {
+		assertThat(homePage.getAllDashboards(), not(hasItem(dashboardName)));
 	}
 	
 	@Step


### PR DESCRIPTION
I have made the following changes
* Fixes for the tests from PR1264
* Added story, step definition, page objects and test for delete dashboard
```Scenario: User deletes a dashboard
Using timeout for story delete_dashboard_test.story of 300 secs.
Given I am an authorized project stakeholder
And I am on the Hygieia home screen
When I delete a team dashboard
Then the dashboard 'DummyDashboard' should be deleted
```
* Updated README.md for `Executing Tests Without Docker Setup`

All Tests are passed without any issues
```Reports view generated with 4 stories (of which 0 pending) containing 4 scenarios (of which 0 pending)
Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 38.06 sec - in com.capitalone.dashboard.uitest.UITestRunner

Results :
Tests run: 28, Failures: 0, Errors: 0, Skipped: 0```