### PR TITLE
Update setup.md

### DIFF
--- a/pages/hygieia/setup.md
+++ b/pages/hygieia/setup.md
@@ -35,8 +35,8 @@ The following components are required to run Hygieia℠:
          MongoDB shell version: 3.0.4
          connecting to: test  
          
-         > use dashboarddb
-         switched to db dashboarddb
+         > use dashboard
+         switched to db dashboard
          > db.createUser(
                   {
                     user: "dashboarduser",


### PR DESCRIPTION
Changing the database setup from "use dashboarddb" to "use dashboard" and the output message from "switched to db dashboarddb" to "switched to dashboard". The db name is dashboard so this setup causes issues when setting up other properties files and calling the database dashboard and the dashboard user has no readWrite permissions to it.