### PR TITLE
Fix incorrect docker image names #1690

### DIFF
--- a/collectors/build/bamboo/pom.xml
+++ b/collectors/build/bamboo/pom.xml
@@ -42,7 +42,7 @@
         <artifactId>docker-maven-plugin</artifactId>
         <configuration>
           <skipDockerBuild>false</skipDockerBuild>
-          <imageName>hygieia-jenkins-build-collector</imageName>
+          <imageName>hygieia-bamboo-build-collector</imageName>
           <dockerDirectory>${project.basedir}/docker</dockerDirectory>
           <resources>
             <resource>

--- a/collectors/build/jenkins-codequality/pom.xml
+++ b/collectors/build/jenkins-codequality/pom.xml
@@ -44,7 +44,7 @@
                 <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skipDockerBuild>false</skipDockerBuild>
-                    <imageName>hygieia-jenkins-build-collector</imageName>
+                    <imageName>hygieia-jenkins-codequality-collector</imageName>
                     <dockerDirectory>${project.basedir}/docker</dockerDirectory>
                     <resources>
                         <resource>


### PR DESCRIPTION
Both the bamboo and jenkins codequality collectors are using the docker image name "hygieia-jenkins-build-collector". This causes the real hygieia jenkins build collector docker image to get overwritten.

Resolves #1690