### PR TITLE
Fix accept header for xml to xld collector

### DIFF
--- a/collectors/deploy/xldeploy/src/main/java/com/capitalone/dashboard/collector/DefaultXLDeployClient.java
+++ b/collectors/deploy/xldeploy/src/main/java/com/capitalone/dashboard/collector/DefaultXLDeployClient.java
@@ -243,6 +243,7 @@ public class DefaultXLDeployClient implements XLDeployClient {
 
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", authHeader);
+        headers.set("Accept", "application/xml");
         return headers;
     }
     


### PR DESCRIPTION
XLD 6.x seems to default to returning json on a query where it used to default to returning XML. Add an accept header to make sure we get XML back.