### PR TITLE
Add log to track progress of jenkins job retrieval.

### DIFF
--- a/collectors/build/jenkins/src/main/java/com/capitalone/dashboard/collector/DefaultHudsonClient.java
+++ b/collectors/build/jenkins/src/main/java/com/capitalone/dashboard/collector/DefaultHudsonClient.java
@@ -116,6 +116,8 @@ public class DefaultHudsonClient implements HudsonClient {
         	pageSize = 1000;
         }
         while (i < jobsCount) {
+        	LOG.info("Fetching jobs " + i + "/" + jobsCount + " pageSize " + settings.getPageSize() + "...");
+        	
 	        try {
                 String url = joinURL(instanceUrl, API_SUFFIX + buildJobQueryString() + URLEncoder.encode("{" + i + "," + (i + pageSize) + "}", "UTF-8"));
 	            ResponseEntity<String> responseEntity = makeRestCall(url);


### PR DESCRIPTION
Add a simple log statement that gives the progress of Jenkins job retrieval. Useful for knowing the state of a job pull - sometimes on large instances Jenkins chokes (cause unknown) resulting in the pull taking a half hour.

Example:

> 2017-08-31 12:24:17,354 INFO  c.c.d.collector.DefaultHudsonClient - Fetching jobs 0/4185 pageSize 250...
> 2017-08-31 12:24:18,368 INFO  c.c.d.collector.DefaultHudsonClient - Fetching jobs 250/4185 pageSize 250...
> 2017-08-31 12:24:19,098 INFO  c.c.d.collector.DefaultHudsonClient - Fetching jobs 500/4185 pageSize 250...
> 2017-08-31 12:24:20,058 INFO  c.c.d.collector.DefaultHudsonClient - Fetching jobs 750/4185 pageSize 250...
> 2017-08-31 12:24:21,676 INFO  c.c.d.collector.DefaultHudsonClient - Fetching jobs 1000/4185 pageSize 250...
> 2017-08-31 12:24:24,917 INFO  c.c.d.collector.DefaultHudsonClient - Fetching jobs 1250/4185 pageSize 250...