### PR TITLE
Fix for sonar collector for v6.0-v6.2

### DIFF
--- a/collectors/build/sonar/src/main/java/com/capitalone/dashboard/collector/SonarClientSelector.java
+++ b/collectors/build/sonar/src/main/java/com/capitalone/dashboard/collector/SonarClientSelector.java
@@ -17,6 +17,6 @@ public class SonarClientSelector {
     }
 
     public SonarClient getSonarClient(Double version) {
-        return ((version == null) || (version < 6.0)) ? sonarClient : sonar6Client;
+        return ((version == null) || (version < 6.3)) ? sonarClient : sonar6Client;
     }
 }


### PR DESCRIPTION
Fix for issue #1517 #1311  Sonarqube v6.0-v6.2 returning 404 
Changes : 
DefaultSonar6Client has sonar API URLs which  is supported only for sonar 6.3 and above. 
For sonar version 6.2 and below DefaultSonarClient should be used.