### PR TITLE
Support configuring a proxy to access the jenkins server

### DIFF
--- a/collectors/build/jenkins/src/main/java/com/capitalone/dashboard/collector/HudsonSettings.java
+++ b/collectors/build/jenkins/src/main/java/com/capitalone/dashboard/collector/HudsonSettings.java
@@ -27,6 +27,8 @@ public class HudsonSettings {
     @Value("${folderDepth:10}")
     private int folderDepth;
 
+    private String proxy;
+    
     public String getCron() {
         return cron;
     }
@@ -115,4 +117,13 @@ public class HudsonSettings {
     public int getFolderDepth() {
         return folderDepth;
     }
+
+	public String getProxy() {
+		return proxy;
+	}
+
+	public void setProxy(String proxy) {
+		this.proxy = proxy;
+	}
+    
 }

--- a/collectors/build/jenkins/src/main/java/com/capitalone/dashboard/collector/RestOperationsSupplier.java
+++ b/collectors/build/jenkins/src/main/java/com/capitalone/dashboard/collector/RestOperationsSupplier.java
@@ -1,6 +1,14 @@
 package com.capitalone.dashboard.collector;
 
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.Proxy.Type;
+
 import com.capitalone.dashboard.util.Supplier;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
@@ -10,8 +18,29 @@ import org.springframework.web.client.RestTemplate;
  */
 @Component
 public class RestOperationsSupplier implements Supplier<RestOperations> {
+	
+	private final HudsonSettings settings;
+	
+    @Autowired
+    public RestOperationsSupplier(HudsonSettings settings) {
+        this.settings = settings;
+    }
+    
     @Override
     public RestOperations get() {
-        return new RestTemplate();
+        if (StringUtils.isNotEmpty(this.settings.getProxy())) {
+        	String proxy = this.settings.getProxy();
+        	String[] proxyArray = proxy.split(":");
+        	SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+            
+            if (proxyArray.length == 1) {
+            	requestFactory.setProxy(new Proxy(Type.HTTP, new InetSocketAddress(proxyArray[0], 80)));
+			}else {
+				requestFactory.setProxy(new Proxy(Type.HTTP, new InetSocketAddress(proxyArray[0], Integer.parseInt(proxyArray[1]))));
+			}
+            return new RestTemplate(requestFactory);
+		}else {
+			return new RestTemplate();
+		}
     }
 }


### PR DESCRIPTION
For the issue: https://github.com/capitalone/Hygieia/issues/1506
When the hygieia server need a proxy to access the jenkins server, the user can't configure it in current jenkins collector, so I make some changes in HudsonSettings.java, RestOperationsSupplier.java and application.properties to support configuring proxy.

1.Change the HudsonSettings.java file
Add a new property
private String proxy;
public String getProxy() {
return proxy;
}
public void setProxy(String proxy) {
this.proxy = proxy;
}
2.Change the properties file.
Add a new propery "jenkins.proxy".
3.Change the RestOperationsSupplier.java file.
Add the proxy when create RestTemplate object if proxy has been configured.
@component
public class RestOperationsSupplier implements Supplier {

private final HudsonSettings settings;

@Autowired
public RestOperationsSupplier(HudsonSettings settings) {
    this.settings = settings;
}

@Override
public RestOperations get() {
    if (StringUtils.isNotEmpty(this.settings.getProxy())) {
    	String proxy = this.settings.getProxy();
    	String[] proxyArray = proxy.split(":");
    	SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
        
        if (proxyArray.length == 1) {
        	requestFactory.setProxy(new Proxy(Type.HTTP, new InetSocketAddress(proxyArray[0], 80)));
		}else {
			requestFactory.setProxy(new Proxy(Type.HTTP, new InetSocketAddress(proxyArray[0], Integer.parseInt(proxyArray[1]))));
		}
        return new RestTemplate(requestFactory);
	}else {
		return new RestTemplate();
	}
}
}

The diff patch file.
[patch.zip](https://github.com/capitalone/Hygieia/files/1335684/patch.zip)
