### PR TITLE
Approval management

### DIFF
--- a/api-audit/src/main/java/com/capitalone/dashboard/ApiSettings.java
+++ b/api-audit/src/main/java/com/capitalone/dashboard/ApiSettings.java
@@ -15,6 +15,7 @@ public class ApiSettings {
     @Value("${corsEnabled:false}")
     private boolean corsEnabled;
     private String corsWhitelist;
+    private String peerReviewContexts;
     private boolean logRequest;
     
     public String getKey() {
@@ -39,6 +40,14 @@ public class ApiSettings {
 
     public void setCorsWhitelist(String corsWhitelist) {
         this.corsWhitelist = corsWhitelist;
+    }
+
+    public String getPeerReviewContexts() {
+        return peerReviewContexts;
+    }
+
+    public void setPeerReviewContexts(String peerReviewContexts) {
+        this.peerReviewContexts = peerReviewContexts;
     }
 
     public boolean isLogRequest() {

--- a/api-audit/src/main/java/com/capitalone/dashboard/service/AuditServiceImpl.java
+++ b/api-audit/src/main/java/com/capitalone/dashboard/service/AuditServiceImpl.java
@@ -17,6 +17,7 @@ import com.capitalone.dashboard.model.Dashboard;
 import com.capitalone.dashboard.model.GitRequest;
 import com.capitalone.dashboard.model.JobCollectorItem;
 import com.capitalone.dashboard.model.RepoBranch;
+import com.capitalone.dashboard.model.Review;
 import com.capitalone.dashboard.model.Widget;
 import com.capitalone.dashboard.repository.BuildRepository;
 import com.capitalone.dashboard.repository.CmdbRepository;
@@ -289,15 +290,23 @@ public class AuditServiceImpl implements AuditService {
 
     boolean computePeerReviewStatus(GitRequest pr) {
         List<CommitStatus> statuses = pr.getCommitStatuses();
+        List<Review> reviews = pr.getReviews();
         if (statuses != null) {
-            Set<String> contexts = new HashSet<>();
-            String allContexts = settings.getPeerReviewContexts();
-            if (allContexts != null) {
-                contexts.addAll(Arrays.asList(allContexts.trim().split(",")));
+            Set<String> prContexts = new HashSet<>();
+            String contextString = settings.getPeerReviewContexts();
+            if (contextString != null) {
+                prContexts.addAll(Arrays.asList(contextString.trim().split(",")));
             }
             for (CommitStatus status : statuses) {
-                if (contexts.contains(status.getContext())) {
-                    return "success".equals(status.getState());
+                if (prContexts.contains(status.getContext())) {
+                    return "success".equalsIgnoreCase(status.getState());
+                }
+            }
+        }
+        if (reviews != null) {
+            for (Review review : reviews) {
+                if ("approved".equalsIgnoreCase(review.getState())) {
+                    return true;
                 }
             }
         }

--- a/api-audit/src/test/java/com/capitalone/dashboard/service/AuditServiceTest.java
+++ b/api-audit/src/test/java/com/capitalone/dashboard/service/AuditServiceTest.java
@@ -1,7 +1,9 @@
 package com.capitalone.dashboard.service;
 
+import com.capitalone.dashboard.ApiSettings;
 import com.capitalone.dashboard.model.Comment;
 import com.capitalone.dashboard.model.Commit;
+import com.capitalone.dashboard.model.CommitStatus;
 import com.capitalone.dashboard.model.CommitType;
 import com.capitalone.dashboard.model.GitRequest;
 import com.capitalone.dashboard.repository.CommitRepository;
@@ -17,6 +19,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -27,9 +30,30 @@ public class AuditServiceTest {
     private GitRequestRepository gitRequestRepository;
     @Mock
     private CommitRepository commitRepository;
+    @Mock
+    private ApiSettings settings;
 
     @InjectMocks
     private AuditServiceImpl auditService;
+
+    @Test
+    public void shouldPeerReview() {
+        when(settings.getPeerReviewContexts()).thenReturn("foo");
+        GitRequest gitRequest = new GitRequest();
+        assertFalse(auditService.computePeerReviewStatus(gitRequest));
+        List<CommitStatus> commitStatuses = new ArrayList<>();
+        CommitStatus status = new CommitStatus();
+        status.setContext("bar");
+        status.setState("success");
+        commitStatuses.add(status);
+        gitRequest.setCommitStatuses(commitStatuses);
+        assertFalse(auditService.computePeerReviewStatus(gitRequest));
+        status.setContext("foo");
+        status.setState(null);
+        assertFalse(auditService.computePeerReviewStatus(gitRequest));
+        status.setState("success");
+        assertTrue(auditService.computePeerReviewStatus(gitRequest));
+    }
 
     @Test
     public void shouldGetPullRequestsForRepoAndBranch() {

--- a/api-audit/src/test/java/com/capitalone/dashboard/service/AuditServiceTest.java
+++ b/api-audit/src/test/java/com/capitalone/dashboard/service/AuditServiceTest.java
@@ -6,6 +6,7 @@ import com.capitalone.dashboard.model.Commit;
 import com.capitalone.dashboard.model.CommitStatus;
 import com.capitalone.dashboard.model.CommitType;
 import com.capitalone.dashboard.model.GitRequest;
+import com.capitalone.dashboard.model.Review;
 import com.capitalone.dashboard.repository.CommitRepository;
 import com.capitalone.dashboard.repository.GitRequestRepository;
 import com.capitalone.dashboard.request.PeerReviewRequest;
@@ -37,22 +38,49 @@ public class AuditServiceTest {
     private AuditServiceImpl auditService;
 
     @Test
-    public void shouldPeerReview() {
+    public void emptyPeerReview() {
         when(settings.getPeerReviewContexts()).thenReturn("foo");
         GitRequest gitRequest = new GitRequest();
         assertFalse(auditService.computePeerReviewStatus(gitRequest));
+    }
+
+    @Test
+    public void peerReviewWithCommitStatus() {
+        when(settings.getPeerReviewContexts()).thenReturn("foo");
+        GitRequest gitRequest = new GitRequest();
         List<CommitStatus> commitStatuses = new ArrayList<>();
         CommitStatus status = new CommitStatus();
         status.setContext("bar");
-        status.setState("success");
+        status.setState("SUCCESS");
         commitStatuses.add(status);
         gitRequest.setCommitStatuses(commitStatuses);
         assertFalse(auditService.computePeerReviewStatus(gitRequest));
         status.setContext("foo");
         status.setState(null);
         assertFalse(auditService.computePeerReviewStatus(gitRequest));
-        status.setState("success");
+        status.setState("SUCCESS");
         assertTrue(auditService.computePeerReviewStatus(gitRequest));
+    }
+
+    @Test
+    public void peerReviewWithReviews() {
+        when(settings.getPeerReviewContexts()).thenReturn("foo");
+        GitRequest gitRequest = new GitRequest();
+        Review review = new Review();
+        review.setState("PENDING");
+        List<Review> reviews = new ArrayList<>();
+        reviews.add(review);
+        gitRequest.setReviews(reviews);
+        assertFalse(auditService.computePeerReviewStatus(gitRequest));
+        review.setState("APPROVED");
+        assertTrue(auditService.computePeerReviewStatus(gitRequest));
+        List<CommitStatus> commitStatuses = new ArrayList<>();
+        CommitStatus status = new CommitStatus();
+        commitStatuses.add(status);
+        gitRequest.setCommitStatuses(commitStatuses);
+        status.setContext("foo");
+        status.setState(null);
+        assertFalse(auditService.computePeerReviewStatus(gitRequest));
     }
 
     @Test

--- a/core/src/main/java/com/capitalone/dashboard/model/CommitStatus.java
+++ b/core/src/main/java/com/capitalone/dashboard/model/CommitStatus.java
@@ -1,0 +1,31 @@
+package com.capitalone.dashboard.model;
+
+public class CommitStatus {
+    private String state;
+    private String context;
+    private String description;
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getContext() {
+        return context;
+    }
+
+    public void setContext(String context) {
+        this.context = context;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/core/src/main/java/com/capitalone/dashboard/model/GitRequest.java
+++ b/core/src/main/java/com/capitalone/dashboard/model/GitRequest.java
@@ -32,6 +32,7 @@ public class GitRequest extends SCM {
     private String reviewCommentsUrl;
     private List<Comment> comments;
     private List<Comment> reviewComments;
+    private List<CommitStatus> commitStatuses;
     private String headSha;
     private String baseSha;
 
@@ -203,6 +204,14 @@ public class GitRequest extends SCM {
 
     public void setReviewComments(List<Comment> reviewComments) {
         this.reviewComments = reviewComments;
+    }
+
+    public List<CommitStatus> getCommitStatuses() {
+        return commitStatuses;
+    }
+
+    public void setCommitStatuses(List<CommitStatus> commitStatuses) {
+        this.commitStatuses = commitStatuses;
     }
 
     public String getHeadSha() {

--- a/core/src/main/java/com/capitalone/dashboard/model/GitRequest.java
+++ b/core/src/main/java/com/capitalone/dashboard/model/GitRequest.java
@@ -32,6 +32,7 @@ public class GitRequest extends SCM {
     private String reviewCommentsUrl;
     private List<Comment> comments;
     private List<Comment> reviewComments;
+    private List<Review> reviews;
     private List<CommitStatus> commitStatuses;
     private String headSha;
     private String baseSha;
@@ -204,6 +205,14 @@ public class GitRequest extends SCM {
 
     public void setReviewComments(List<Comment> reviewComments) {
         this.reviewComments = reviewComments;
+    }
+
+    public List<Review> getReviews() {
+        return reviews;
+    }
+
+    public void setReviews(List<Review> reviews) {
+        this.reviews = reviews;
     }
 
     public List<CommitStatus> getCommitStatuses() {

--- a/core/src/main/java/com/capitalone/dashboard/model/Review.java
+++ b/core/src/main/java/com/capitalone/dashboard/model/Review.java
@@ -1,0 +1,31 @@
+package com.capitalone.dashboard.model;
+
+public class Review {
+    private int id;
+    private String body;
+    private String state;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+}


### PR DESCRIPTION
Tests peer review using either GitHub commit statuses or GitHub reviews. If the Hygieia API settings are populated with a list of peer review contexts then test the commit statuses.  When a commit status with a matching context is found, then use the state of the commit status to indicate peer review. If the Hygieia API settings do not have a peer review context then do not use the commit status.

When no peer review commit status is found then fallback to using GitHub Reviews. Check for at least one approved review. GitHub Reviews does not allow self-review. Closes #1735