### PR TITLE
UI conf-builder.sh to have sensible default for API_HOST

### DIFF
--- a/UI/docker/conf-builder.sh
+++ b/UI/docker/conf-builder.sh
@@ -1,10 +1,4 @@
 #!/bin/bash
 
-
-# if we are linked, use that info
-#linked containers now use hostnames
-export API_HOST=hygieia-api
-export API_PORT=8080
-
-sed s:API_HOST:${API_HOST:-127.0.0.1}: /etc/nginx/conf.d/default.conf.templ |\
+sed s:API_HOST:${API_HOST:-hygieia-api}: /etc/nginx/conf.d/default.conf.templ |\
   sed s:API_PORT:${API_PORT:-8080}: > /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
This solves issue [#1856](https://github.com/capitalone/Hygieia/issues/1856). In the current state no matter what you attempt to set API_HOST to, you always get 'hygieia-api' as the hostname. In addition 127.0.0.1 is the current default which is rather useless as the api will never be reachable at this address.

The solution: remove the two export statements because they interfere with a user's ability to set the api hostname using ENV vars. Also change '127.0.0.1' to 'hygieia-api' since that hostname will be provided for you if you are using container linking or networking.
