### PR TITLE
Returns from function for no profile configuration change

### DIFF
--- a/api-audit/src/main/java/com/capitalone/dashboard/evaluator/CodeQualityEvaluator.java
+++ b/api-audit/src/main/java/com/capitalone/dashboard/evaluator/CodeQualityEvaluator.java
@@ -122,6 +122,7 @@ public class CodeQualityEvaluator extends Evaluator<CodeQualityAuditResponse> {
         List<CollectorItemConfigHistory> configHistories = getProfileChanges(returnQuality, beginDate, endDate);
         if (CollectionUtils.isEmpty(configHistories)) {
             codeQualityAuditResponse.addAuditStatus(CodeQualityAuditStatus.QUALITY_PROFILE_VALIDATION_AUDIT_NO_CHANGE);
+            return codeQualityAuditResponse;
         }
         Set<String> codeAuthors = CommonCodeReview.getCodeAuthors(repoItems, beginDate, endDate, commitRepository);
         List<String> overlap = configHistories.stream().map(CollectorItemConfigHistory::getUserID).filter(codeAuthors::contains).collect(Collectors.toList());


### PR DESCRIPTION
This will prevent a dual audit status for the quality profile validation
as it currently returns an audit status of
**QUALITY_PROFILE_VALIDATION_AUDIT_NO_CHANGE** and
**QUALITY_PROFILE_VALIDATION_AUDIT_OK** even if there is no change in the
quality profile validation

@satishc1 @tabladrum 