### PR TITLE
Code Quality Widget - Disable "View All" if no scan has been performed yet

### DIFF
--- a/UI/src/components/widgets/codeanalysis/view.html
+++ b/UI/src/components/widgets/codeanalysis/view.html
@@ -19,7 +19,7 @@
                             <div class="widget-body">
                                 <div class="widget ca-issues">
                                     <br>
-                                    <a href="{{caWidget.reportUrl}}" target="_blank">
+                                    <a ng-href="{{caWidget.reportUrl ? caWidget.reportUrl : ''}}" target="_blank">
                                 <span class="report-link pull-left">View All <i class="fa fa-arrow-right"
                                                                                 aria-hidden="true"></i></span>
                                     </a> <br>


### PR DESCRIPTION
If no scan data is present in the db then the "View All" button on the Code Quality widget will set an empty href. In this case when you click on the button it will take you the home page since the Hygieia UI is a single page app. This PR uses ng-href instead which supports expressions. So now if there is no scan data then caWidget.reportUrl will evaluate to false and no href will be set. 