### PR TITLE
Modify error handling

### DIFF
--- a/api-audit/src/main/java/com/capitalone/dashboard/evaluator/CodeReviewEvaluatorLegacy.java
+++ b/api-audit/src/main/java/com/capitalone/dashboard/evaluator/CodeReviewEvaluatorLegacy.java
@@ -74,6 +74,8 @@ public class CodeReviewEvaluatorLegacy extends LegacyEvaluator {
 
         if (repoItem == null) {
             CodeReviewAuditResponse codeReviewAuditResponse = new CodeReviewAuditResponse();
+            codeReviewAuditResponse.addAuditStatus(CodeReviewAuditStatus.REPO_NOT_CONFIGURED);
+
             allPeerReviews.add(codeReviewAuditResponse);
             return allPeerReviews;
         }
@@ -91,8 +93,21 @@ public class CodeReviewEvaluatorLegacy extends LegacyEvaluator {
             return allPeerReviews;
         }
 
+        //if there are errors on the collector item
         if (!CollectionUtils.isEmpty(repoItem.getErrors())) {
             CodeReviewAuditResponse noPRsCodeReviewAuditResponse = getErrorResponse(repoItem, scmBranch, parsedUrl);
+            allPeerReviews.add(noPRsCodeReviewAuditResponse);
+            return allPeerReviews;
+        }
+
+        //if the collector item is pending data collection
+        if (repoItem.getLastUpdated() == 0) {
+            CodeReviewAuditResponse noPRsCodeReviewAuditResponse = new CodeReviewAuditResponse();
+            noPRsCodeReviewAuditResponse.addAuditStatus(CodeReviewAuditStatus.PENDING_DATA_COLLECTION);
+
+            noPRsCodeReviewAuditResponse.setLastUpdated(repoItem.getLastUpdated());
+            noPRsCodeReviewAuditResponse.setScmBranch(scmBranch);
+            noPRsCodeReviewAuditResponse.setScmUrl(scmUrl);
             allPeerReviews.add(noPRsCodeReviewAuditResponse);
             return allPeerReviews;
         }

--- a/api-audit/src/main/java/com/capitalone/dashboard/status/CodeReviewAuditStatus.java
+++ b/api-audit/src/main/java/com/capitalone/dashboard/status/CodeReviewAuditStatus.java
@@ -32,6 +32,9 @@ public enum CodeReviewAuditStatus {
     GIT_BRANCH_STRATEGY,
     GIT_NO_WORKFLOW,
 
+    REPO_NOT_CONFIGURED,
+    PENDING_DATA_COLLECTION,
+
     NO_COMMIT_FOR_DATE_RANGE, //Removew this later when we can remove legacy peer review
     COMMIT_AFTER_PR_MERGE, COLLECTOR_ITEM_ERROR
 }

--- a/api/src/main/java/com/capitalone/dashboard/service/CollectorServiceImpl.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/CollectorServiceImpl.java
@@ -155,7 +155,10 @@ public class CollectorServiceImpl implements CollectorService {
                 item.getCollectorId(), allOptions, uniqueOptions);
 
         if (!CollectionUtils.isEmpty(existing)) {
-            item.setId(existing.get(0).getId());   //
+            CollectorItem existingItem = existing.get(0);
+            existingItem.getOptions().clear();
+            existingItem.getOptions().putAll(item.getOptions());
+            return collectorItemRepository.save(existingItem);
         }
         return collectorItemRepository.save(item);
     }

--- a/core/src/main/java/com/capitalone/dashboard/model/CollectorItem.java
+++ b/core/src/main/java/com/capitalone/dashboard/model/CollectorItem.java
@@ -1,5 +1,6 @@
 package com.capitalone.dashboard.model;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -125,7 +126,11 @@ public class CollectorItem extends BaseModel {
         Optional<CollectionError> lastErrorOptional = errors.stream().max(Comparator.comparingLong(CollectionError::getTimestamp));
         long lastErrorTimestamp = lastErrorOptional.isPresent() ? lastErrorOptional.get().getTimestamp() : System.currentTimeMillis();
         if ((System.currentTimeMillis() - lastErrorTimestamp) >= resetWindow) {
-            errors.clear();
+            //clear the oldest error so errors count drops below threshold
+            if (!CollectionUtils.isEmpty(errors)) {
+                errors.sort(Comparator.comparing(CollectionError::getTimestamp));
+                errors.remove(0);
+            }
             return true;
         } else {
             return (errors.size() <= errorThreshold);


### PR DESCRIPTION
Changes a couple of things:
1. Adds repo_not_configured and pending_data_collection statuses to codereviewaudit.
2. Doesn't clear out errors when the remoteUpdate api updates a collector item.
3. Changes the reset logic for a collector item where instead of clearing all errors, it only clears the oldest one so as to drop it below the threshold count.