### PR TITLE
Set DB properties to the correct defaults in all collectors

### DIFF
--- a/api-audit/docker/properties-builder.sh
+++ b/api-audit/docker/properties-builder.sh
@@ -27,7 +27,7 @@ dbhost=${SPRING_DATA_MONGODB_HOST:-10.0.1.1}
 dbport=${SPRING_DATA_MONGODB_PORT:-9999}
 
 #Database Username - default is blank
-dbusername=${SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
 dbpassword=${SPRING_DATA_MONGODB_PASSWORD:-dbpass}

--- a/api-audit/docker/properties-builder.sh
+++ b/api-audit/docker/properties-builder.sh
@@ -30,7 +30,7 @@ dbport=${SPRING_DATA_MONGODB_PORT:-9999}
 dbusername=${SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 logRequest=${LOG_REQUEST:-false}
 logSplunkRequest=${LOG_SPLUNK_REQUEST:-false}

--- a/api-audit/docker/properties-builder.sh
+++ b/api-audit/docker/properties-builder.sh
@@ -18,7 +18,7 @@ echo "SPRING_DATA_MONGODB_PORT: $SPRING_DATA_MONGODB_PORT"
 
 cat > config/hygieia-api-audit.properties <<EOF
 #Database Name - default is test
-dbname=${SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 
 #Database HostName - default is localhost
 dbhost=${SPRING_DATA_MONGODB_HOST:-10.0.1.1}

--- a/collectors/artifact/artifactory/docker/properties-builder.sh
+++ b/collectors/artifact/artifactory/docker/properties-builder.sh
@@ -33,7 +33,7 @@ dbport=${MONGODB_PORT:-27017}
 dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 #Collector schedule (required)
 artifactory.cron=${ARTIFACTORY_CRON:-0 0/5 * * * *}

--- a/collectors/artifact/artifactory/docker/properties-builder.sh
+++ b/collectors/artifact/artifactory/docker/properties-builder.sh
@@ -30,7 +30,7 @@ dbhost=${MONGODB_HOST:-10.0.1.1}
 dbport=${MONGODB_PORT:-27017}
 
 #Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
 dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}

--- a/collectors/build/bamboo/docker/properties-builder.sh
+++ b/collectors/build/bamboo/docker/properties-builder.sh
@@ -59,7 +59,7 @@ dbport=${MONGODB_PORT:-27017}
 dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 #Collector schedule (required)
 bamboo.cron=${JENKINS_CRON:-0 0/5 * * * *}

--- a/collectors/build/bamboo/docker/properties-builder.sh
+++ b/collectors/build/bamboo/docker/properties-builder.sh
@@ -56,7 +56,7 @@ dbhost=${MONGODB_HOST:-10.0.1.1}
 dbport=${MONGODB_PORT:-27017}
 
 #Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
 dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}

--- a/collectors/build/bamboo/docker/properties-builder.sh
+++ b/collectors/build/bamboo/docker/properties-builder.sh
@@ -47,7 +47,7 @@ fi
 
 cat > $PROP_FILE <<EOF
 #Database Name
-dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/collectors/build/jenkins-codequality/docker/properties-builder.sh
+++ b/collectors/build/jenkins-codequality/docker/properties-builder.sh
@@ -39,7 +39,7 @@ dbhost=${MONGODB_HOST:-10.0.1.1}
 dbport=${MONGODB_PORT:-27017}
 
 #Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
 dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}

--- a/collectors/build/jenkins-codequality/docker/properties-builder.sh
+++ b/collectors/build/jenkins-codequality/docker/properties-builder.sh
@@ -30,7 +30,7 @@ fi
 
 cat > $PROP_FILE <<EOF
 #Database Name
-dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/collectors/build/jenkins-codequality/docker/properties-builder.sh
+++ b/collectors/build/jenkins-codequality/docker/properties-builder.sh
@@ -42,7 +42,7 @@ dbport=${MONGODB_PORT:-27017}
 dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 #Collector schedule (required)
 jenkins-codequality.cron=${JENKINS_CRON:-0 0/5 * * * *}

--- a/collectors/build/jenkins-cucumber/docker/properties-builder.sh
+++ b/collectors/build/jenkins-cucumber/docker/properties-builder.sh
@@ -35,7 +35,7 @@ fi
 
 cat > $PROP_FILE <<EOF
 #Database Name
-dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/collectors/build/jenkins-cucumber/docker/properties-builder.sh
+++ b/collectors/build/jenkins-cucumber/docker/properties-builder.sh
@@ -47,7 +47,7 @@ dbport=${MONGODB_PORT:-27017}
 dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 #Collector schedule (required)
 jenkins-cucumber.cron=${JENKINS_CRON:-0 0/5 * * * *}

--- a/collectors/build/jenkins-cucumber/docker/properties-builder.sh
+++ b/collectors/build/jenkins-cucumber/docker/properties-builder.sh
@@ -44,7 +44,7 @@ dbhost=${MONGODB_HOST:-10.0.1.1}
 dbport=${MONGODB_PORT:-27017}
 
 #Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
 dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}

--- a/collectors/build/jenkins/docker/properties-builder.sh
+++ b/collectors/build/jenkins/docker/properties-builder.sh
@@ -58,7 +58,7 @@ fi
 
 cat > $PROP_FILE <<EOF
 #Database Name
-dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/collectors/build/jenkins/docker/properties-builder.sh
+++ b/collectors/build/jenkins/docker/properties-builder.sh
@@ -67,7 +67,7 @@ dbhost=${MONGODB_HOST:-10.0.1.1}
 dbport=${MONGODB_PORT:-27017}
 
 #Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
 dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}

--- a/collectors/build/jenkins/docker/properties-builder.sh
+++ b/collectors/build/jenkins/docker/properties-builder.sh
@@ -70,7 +70,7 @@ dbport=${MONGODB_PORT:-27017}
 dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 #Collector schedule (required)
 jenkins.cron=${JENKINS_CRON:-0 0/5 * * * *}

--- a/collectors/cmdb/hpsm/docker/properties-builder.sh
+++ b/collectors/cmdb/hpsm/docker/properties-builder.sh
@@ -25,7 +25,7 @@ dbhost=${MONGODB_HOST:-10.0.1.1}
 dbport=${MONGODB_PORT:-27017}
 
 #Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
 dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}

--- a/collectors/cmdb/hpsm/docker/properties-builder.sh
+++ b/collectors/cmdb/hpsm/docker/properties-builder.sh
@@ -16,7 +16,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name
-dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/collectors/cmdb/hpsm/docker/properties-builder.sh
+++ b/collectors/cmdb/hpsm/docker/properties-builder.sh
@@ -28,7 +28,7 @@ dbport=${MONGODB_PORT:-27017}
 dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 #Collector schedule (required)
 hpsm.cron=${HPSM_CRON:-* * 1 * * *}

--- a/collectors/deploy/udeploy/docker/properties-builder.sh
+++ b/collectors/deploy/udeploy/docker/properties-builder.sh
@@ -30,7 +30,7 @@ dbhost=${MONGODB_HOST:-10.0.1.1}
 dbport=${MONGODB_PORT:-27017}
 
 #Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
 dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}

--- a/collectors/deploy/udeploy/docker/properties-builder.sh
+++ b/collectors/deploy/udeploy/docker/properties-builder.sh
@@ -33,7 +33,7 @@ dbport=${MONGODB_PORT:-27017}
 dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 #Collector schedule (required)
 udeploy.cron=${UDEPLOY_CRON:-0 0/5 * * * *}

--- a/collectors/deploy/udeploy/docker/properties-builder.sh
+++ b/collectors/deploy/udeploy/docker/properties-builder.sh
@@ -21,7 +21,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name
-dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/collectors/deploy/xldeploy/docker/properties-builder.sh
+++ b/collectors/deploy/xldeploy/docker/properties-builder.sh
@@ -31,7 +31,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name
-dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/collectors/deploy/xldeploy/docker/properties-builder.sh
+++ b/collectors/deploy/xldeploy/docker/properties-builder.sh
@@ -43,7 +43,7 @@ dbport=${MONGODB_PORT:-27017}
 dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 #Collector schedule (required)
 xldeploy.cron=${XLDEPLOY_CRON:-0 0/5 * * * *}

--- a/collectors/deploy/xldeploy/docker/properties-builder.sh
+++ b/collectors/deploy/xldeploy/docker/properties-builder.sh
@@ -40,7 +40,7 @@ dbhost=${MONGODB_HOST:-10.0.1.1}
 dbport=${MONGODB_PORT:-27017}
 
 #Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
 dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}

--- a/collectors/feature/gitlab/docker/properties-builder.sh
+++ b/collectors/feature/gitlab/docker/properties-builder.sh
@@ -30,7 +30,7 @@ dbhost=${MONGODB_HOST:-10.0.1.1}
 dbport=${MONGODB_PORT:-27017}
 
 #Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
 dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}

--- a/collectors/feature/gitlab/docker/properties-builder.sh
+++ b/collectors/feature/gitlab/docker/properties-builder.sh
@@ -33,7 +33,7 @@ dbport=${MONGODB_PORT:-27017}
 dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 #Collector schedule (required)
 gitlab.cron=${GITLAB_CRON:-0 0/5 * * * *}

--- a/collectors/feature/gitlab/docker/properties-builder.sh
+++ b/collectors/feature/gitlab/docker/properties-builder.sh
@@ -21,7 +21,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name
-dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/collectors/feature/jira/docker/properties-builder.sh
+++ b/collectors/feature/jira/docker/properties-builder.sh
@@ -33,7 +33,7 @@ dbport=${MONGODB_PORT:-27017}
 dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 #Collector schedule (required)
 feature.cron=${JIRA_CRON:-0 * * * * *}

--- a/collectors/feature/jira/docker/properties-builder.sh
+++ b/collectors/feature/jira/docker/properties-builder.sh
@@ -30,7 +30,7 @@ dbport=${MONGODB_PORT:-27017}
 
 
 #Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
 dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}

--- a/collectors/feature/jira/docker/properties-builder.sh
+++ b/collectors/feature/jira/docker/properties-builder.sh
@@ -20,7 +20,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name
-dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/collectors/feature/versionone/docker/properties-builder.sh
+++ b/collectors/feature/versionone/docker/properties-builder.sh
@@ -33,7 +33,7 @@ dbport=${MONGODB_PORT:-27017}
 dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 #Collector schedule (required)
 feature.cron=${VERSIONONE_CRON:-0 0/5 * * * *}

--- a/collectors/feature/versionone/docker/properties-builder.sh
+++ b/collectors/feature/versionone/docker/properties-builder.sh
@@ -30,7 +30,7 @@ dbhost=${MONGODB_HOST:-10.0.1.1}
 dbport=${MONGODB_PORT:-27017}
 
 #Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
 dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}

--- a/collectors/feature/versionone/docker/properties-builder.sh
+++ b/collectors/feature/versionone/docker/properties-builder.sh
@@ -21,7 +21,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name
-dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/collectors/library-policy/nexus-iq-collector/docker/properties-builder.sh
+++ b/collectors/library-policy/nexus-iq-collector/docker/properties-builder.sh
@@ -34,7 +34,7 @@ fi
 
 cat > $PROP_FILE <<EOF
 #Database Name
-dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/collectors/library-policy/nexus-iq-collector/docker/properties-builder.sh
+++ b/collectors/library-policy/nexus-iq-collector/docker/properties-builder.sh
@@ -43,7 +43,7 @@ dbhost=${MONGODB_HOST:-10.0.1.1}
 dbport=${MONGODB_PORT:-27017}
 
 #Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
 dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}

--- a/collectors/library-policy/nexus-iq-collector/docker/properties-builder.sh
+++ b/collectors/library-policy/nexus-iq-collector/docker/properties-builder.sh
@@ -46,7 +46,7 @@ dbport=${MONGODB_PORT:-27017}
 dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 #Collector schedule (required)
 nexusiq.cron=${NEXUSIQ_CRON:-0 0/5 * * * *}

--- a/collectors/misc/chat-ops/docker/properties-builder.sh
+++ b/collectors/misc/chat-ops/docker/properties-builder.sh
@@ -30,7 +30,7 @@ dbhost=${MONGODB_HOST:-10.0.1.1}
 dbport=${MONGODB_PORT:-27017}
 
 #Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
 dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}

--- a/collectors/misc/chat-ops/docker/properties-builder.sh
+++ b/collectors/misc/chat-ops/docker/properties-builder.sh
@@ -33,7 +33,7 @@ dbport=${MONGODB_PORT:-27017}
 dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 #Collector schedule (required)
 chatops.cron=${CHATOPS_CRON:-5 * * * * *}

--- a/collectors/misc/chat-ops/docker/properties-builder.sh
+++ b/collectors/misc/chat-ops/docker/properties-builder.sh
@@ -21,7 +21,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name
-dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/collectors/misc/score/docker/Dockerfile
+++ b/collectors/misc/score/docker/Dockerfile
@@ -7,12 +7,12 @@ RUN \
   mkdir /hygieia
 
 COPY *.jar /hygieia/
-COPY score-properties-builder.sh /hygieia/
+COPY properties-builder.sh /hygieia/
 
 WORKDIR /hygieia
 
 VOLUME ["/hygieia/logs"]
 
-CMD ./score-properties-builder.sh && \
+CMD ./properties-builder.sh && \
   java -jar score-collector*.jar --spring.config.location=/hygieia/hygieia-score-collector.properties
 

--- a/collectors/misc/score/docker/Dockerfile
+++ b/collectors/misc/score/docker/Dockerfile
@@ -7,12 +7,12 @@ RUN \
   mkdir /hygieia
 
 COPY *.jar /hygieia/
-COPY properties-builder.sh /hygieia/
+COPY score-properties-builder.sh /hygieia/
 
 WORKDIR /hygieia
 
 VOLUME ["/hygieia/logs"]
 
-CMD ./properties-builder.sh && \
+CMD ./score-properties-builder.sh && \
   java -jar score-collector*.jar --spring.config.location=/hygieia/hygieia-score-collector.properties
 

--- a/collectors/misc/score/docker/properties-builder.sh
+++ b/collectors/misc/score/docker/properties-builder.sh
@@ -8,7 +8,7 @@ fi
 
 cat > $PROP_FILE <<EOF
 #Database Name
-dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/collectors/misc/score/docker/properties-builder.sh
+++ b/collectors/misc/score/docker/properties-builder.sh
@@ -17,7 +17,7 @@ dbhost=${MONGODB_HOST:-10.0.1.1}
 dbport=${MONGODB_PORT:-27017}
 
 #Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
 dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}

--- a/collectors/misc/score/docker/properties-builder.sh
+++ b/collectors/misc/score/docker/properties-builder.sh
@@ -20,7 +20,7 @@ dbport=${MONGODB_PORT:-27017}
 dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 #Collector schedule (required)
 score.cron=${SCORE_CRON:-0 0/5 * * * *}

--- a/collectors/performance/appdynamics/docker/properties-builder.sh
+++ b/collectors/performance/appdynamics/docker/properties-builder.sh
@@ -41,7 +41,7 @@ dbport=${SPRING_DATA_MONGODB_PORT:-27017}
 dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 #Logging File
 logging.file=${APPDYNAMICS_LOGFILE:-./logs/appd-collector.log}

--- a/collectors/performance/appdynamics/docker/properties-builder.sh
+++ b/collectors/performance/appdynamics/docker/properties-builder.sh
@@ -29,7 +29,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name - default is test
-database=${SPRING_DATA_MONGODB_DATABASE:-dashboard}
+database=${SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 
 #Database HostName - default is localhost
 dbhost=${SPRING_DATA_MONGODB_HOST:-10.0.1.1}

--- a/collectors/performance/appdynamics/docker/properties-builder.sh
+++ b/collectors/performance/appdynamics/docker/properties-builder.sh
@@ -38,7 +38,7 @@ dbhost=${SPRING_DATA_MONGODB_HOST:-10.0.1.1}
 dbport=${SPRING_DATA_MONGODB_PORT:-27017}
 
 #Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
 dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}

--- a/collectors/scm/bitbucket/docker/properties-builder.sh
+++ b/collectors/scm/bitbucket/docker/properties-builder.sh
@@ -33,7 +33,7 @@ dbport=${MONGODB_PORT:-27017}
 dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 #Collector schedule (required)
 git.cron=${BITBUCKET_CRON:-0 0/5 * * * *}

--- a/collectors/scm/bitbucket/docker/properties-builder.sh
+++ b/collectors/scm/bitbucket/docker/properties-builder.sh
@@ -30,7 +30,7 @@ dbhost=${MONGODB_HOST:-10.0.1.1}
 dbport=${MONGODB_PORT:-27017}
 
 #Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
 dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}

--- a/collectors/scm/bitbucket/docker/properties-builder.sh
+++ b/collectors/scm/bitbucket/docker/properties-builder.sh
@@ -21,7 +21,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name
-dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/collectors/scm/github/docker/properties-builder.sh
+++ b/collectors/scm/github/docker/properties-builder.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 cat > $PROP_FILE <<EOF
 #Database Name
-dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-db}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/collectors/scm/github/docker/properties-builder.sh
+++ b/collectors/scm/github/docker/properties-builder.sh
@@ -10,7 +10,7 @@ dbhost=${MONGODB_HOST:-10.0.1.1}
 dbport=${MONGODB_PORT:-27017}
 
 #Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
 dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}

--- a/collectors/scm/github/docker/properties-builder.sh
+++ b/collectors/scm/github/docker/properties-builder.sh
@@ -13,7 +13,7 @@ dbport=${MONGODB_PORT:-27017}
 dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 #Collector schedule (required)
 github.cron=${GITHUB_CRON:-0 0/5 * * * *}

--- a/collectors/scm/gitlab/docker/properties-builder.sh
+++ b/collectors/scm/gitlab/docker/properties-builder.sh
@@ -41,10 +41,10 @@ dbhost=${MONGODB_HOST:-10.0.1.1}
 dbport=${MONGODB_PORT:-27017}
 
 #Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 #Collector schedule (required)
 gitlab.cron=${GITLAB_CRON:-0 0/5 * * * *}

--- a/collectors/scm/gitlab/docker/properties-builder.sh
+++ b/collectors/scm/gitlab/docker/properties-builder.sh
@@ -32,7 +32,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name
-dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}

--- a/collectors/scm/subversion/docker/properties-builder.sh
+++ b/collectors/scm/subversion/docker/properties-builder.sh
@@ -30,7 +30,7 @@ dbhost=${MONGODB_HOST:-10.0.1.1}
 dbport=${MONGODB_PORT:-27017}
 
 #Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-db}
+dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
 dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}

--- a/collectors/scm/subversion/docker/properties-builder.sh
+++ b/collectors/scm/subversion/docker/properties-builder.sh
@@ -33,7 +33,7 @@ dbport=${MONGODB_PORT:-27017}
 dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 
 #Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpass}
+dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
 #Collector schedule (required)
 subversion.cron=${SUBVERSION_CRON:-0 0/5 * * * *}

--- a/collectors/scm/subversion/docker/properties-builder.sh
+++ b/collectors/scm/subversion/docker/properties-builder.sh
@@ -21,7 +21,7 @@ echo "MONGODB_PORT: $MONGODB_PORT"
 
 cat > $PROP_FILE <<EOF
 #Database Name
-dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboard}
+dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 
 #Database HostName - default is localhost
 dbhost=${MONGODB_HOST:-10.0.1.1}


### PR DESCRIPTION
Some collectors have the correct values but most don't. I took the values from the DB setup script and modified all the properties-builder.sh to use them, so we don't have to provide those in the docker-compose.override.yml for each of the collectors.