### PR TITLE
Chown in UI dockerfiles to change owner on nginx files

### DIFF
--- a/UI/Dockerfile
+++ b/UI/Dockerfile
@@ -3,7 +3,6 @@ FROM docker.io/nginx:latest
 COPY docker/default.conf /etc/nginx/conf.d/default.conf.templ
 COPY docker/conf-builder.sh /usr/bin/conf-builder.sh
 COPY dist /usr/share/nginx/html
-RUN chown nginx:nginx /usr/share/nginx/html
 RUN chown -R nginx:nginx /usr/share/nginx/html/
 
 EXPOSE 80 443

--- a/UI/Dockerfile
+++ b/UI/Dockerfile
@@ -4,6 +4,7 @@ COPY docker/default.conf /etc/nginx/conf.d/default.conf.templ
 COPY docker/conf-builder.sh /usr/bin/conf-builder.sh
 COPY dist /usr/share/nginx/html
 RUN chown nginx:nginx /usr/share/nginx/html
+RUN chown -R nginx:nginx /usr/share/nginx/html/
 
 EXPOSE 80 443
 

--- a/UI/docker/Dockerfile
+++ b/UI/docker/Dockerfile
@@ -3,7 +3,6 @@ FROM docker.io/nginx:latest
 COPY default.conf /etc/nginx/conf.d/default.conf.templ
 COPY conf-builder.sh /usr/bin/conf-builder.sh
 COPY html /usr/share/nginx/html
-RUN chown nginx:nginx /usr/share/nginx/html
 RUN chown -R nginx:nginx /usr/share/nginx/html/
 
 EXPOSE 80 443

--- a/UI/docker/Dockerfile
+++ b/UI/docker/Dockerfile
@@ -4,6 +4,7 @@ COPY default.conf /etc/nginx/conf.d/default.conf.templ
 COPY conf-builder.sh /usr/bin/conf-builder.sh
 COPY html /usr/share/nginx/html
 RUN chown nginx:nginx /usr/share/nginx/html
+RUN chown -R nginx:nginx /usr/share/nginx/html/
 
 EXPOSE 80 443
 


### PR DESCRIPTION
Related to issue #2089

I get a permission denied error from nginx when running the image. Clearing the site data or cookies it not sufficient. If I open a bash in the running image, I can see that the html folder is owned by nginx but all its files belong to root. Chowning them to nginx solves the problem.