### PR TITLE
RegressionTestResultEvaluator Bug Fix

### DIFF
--- a/api-audit/src/main/java/com/capitalone/dashboard/evaluator/RegressionTestResultEvaluator.java
+++ b/api-audit/src/main/java/com/capitalone/dashboard/evaluator/RegressionTestResultEvaluator.java
@@ -33,7 +33,7 @@ public class RegressionTestResultEvaluator extends Evaluator<TestResultsAuditRes
 
     @Override
     public Collection<TestResultsAuditResponse> evaluate(Dashboard dashboard, long beginDate, long endDate, Map<?, ?> dummy) throws AuditException {
-        List<CollectorItem> testItems = getCollectorItems(dashboard, "test", CollectorType.Test);
+        List<CollectorItem> testItems = getCollectorItems(dashboard, "codeanalysis", CollectorType.Test);
         Collection<TestResultsAuditResponse> responses = new ArrayList<>();
         if (CollectionUtils.isEmpty(testItems)) {
             throw new AuditException("No tests configured", AuditException.NO_COLLECTOR_ITEM_CONFIGURED);


### PR DESCRIPTION
Fix for bug https://github.com/capitalone/Hygieia/issues/2101

Due to passing the wrong widgetName in getCollectorItems() for RegressionTestResultEvaluator, status is being displayed as `DASHBOARD_TEST_NOT_CONFIGURED` every time for AuditType: `Test` and the results are not being populated for audit API calls.
