### PR TITLE
Fixed score collector's  Docker Maven plugin docker/Dockerfile's  properties builder reference breakage

### DIFF
--- a/collectors/misc/score/docker/Dockerfile
+++ b/collectors/misc/score/docker/Dockerfile
@@ -7,12 +7,12 @@ RUN \
   mkdir /hygieia
 
 COPY *.jar /hygieia/
-COPY score-properties-builder.sh /hygieia/
+COPY properties-builder.sh /hygieia/
 
 WORKDIR /hygieia
 
 VOLUME ["/hygieia/logs"]
 
-CMD ./score-properties-builder.sh && \
+CMD ./properties-builder.sh && \
   java -jar score-collector*.jar --spring.config.location=/hygieia/hygieia-score-collector.properties
 


### PR DESCRIPTION
to address current, corresponding `mvn docker:build` failure
caused by not fully integrated `docker/properties-builder.sh` rename in #2087 refactor:
https://github.com/capitalone/Hygieia/commit/8093c6412a42c53725bda610ed3db547e08deecf#diff-51e466d6721ee248bcc484896c6b5689
(commit 8093c6412a42c53725bda610ed3db547e08deecf)