### PR TITLE
Update for plugin to store build path instead of name

### DIFF
--- a/hygieia-jenkins-plugin/src/main/java/hygieia/builder/BuildBuilder.java
+++ b/hygieia-jenkins-plugin/src/main/java/hygieia/builder/BuildBuilder.java
@@ -63,7 +63,7 @@ public class BuildBuilder {
     private void createBuildRequestFromRun() {
         request = new BuildDataCreateRequest();
         request.setNiceName(jenkinsName);
-        request.setJobName(HygieiaUtils.getJobName(run));
+        request.setJobName(HygieiaUtils.getJobPath(run));
         request.setBuildUrl(HygieiaUtils.getBuildUrl(run));
         request.setJobUrl(HygieiaUtils.getJobUrl(run));
         request.setInstanceUrl(HygieiaUtils.getInstanceUrl(run, listener));
@@ -85,7 +85,7 @@ public class BuildBuilder {
     private void createBuildRequest() {
         request = new BuildDataCreateRequest();
         request.setNiceName(jenkinsName);
-        request.setJobName(HygieiaUtils.getJobName(build));
+        request.setJobName(HygieiaUtils.getJobPath(build));
         request.setBuildUrl(HygieiaUtils.getBuildUrl(build));
         request.setJobUrl(HygieiaUtils.getJobUrl(build));
         request.setInstanceUrl(HygieiaUtils.getInstanceUrl(build, listener));

--- a/hygieia-jenkins-plugin/src/main/java/hygieia/utils/HygieiaUtils.java
+++ b/hygieia-jenkins-plugin/src/main/java/hygieia/utils/HygieiaUtils.java
@@ -33,6 +33,7 @@ import java.util.logging.Logger;
 public class HygieiaUtils {
     private static final Logger logger = Logger.getLogger(HygieiaUtils.class.getName());
     public static final String APPLICATION_JSON_VALUE = "application/json";
+    public static final String JOB_URL_SEARCH_PARM = "job/";
 
     public static byte[] convertObjectToJsonBytes(Object object) throws IOException {
         ObjectMapper mapper = new CustomObjectMapper();
@@ -132,6 +133,7 @@ public class HygieiaUtils {
     }
 
     public static String getJobUrl(Run<?, ?> run) {
+
         return run.getParent().getAbsoluteUrl();
     }
 
@@ -146,12 +148,16 @@ public class HygieiaUtils {
 
     public static String getJobPath(AbstractBuild<?, ?> build){
         String jobUrl = getJobUrl(build);
-        String jobPath = jobUrl.substring(jobUrl.indexOf("job/") , jobUrl.length());
+        if(jobUrl == null || !jobUrl.contains(JOB_URL_SEARCH_PARM))return build.getProject().getName();
+
+        String jobPath = jobUrl.substring(jobUrl.indexOf(JOB_URL_SEARCH_PARM) , jobUrl.length());
         return jobPath;
     }
     public static String getJobPath(Run<?, ?> run){
         String jobUrl = getJobUrl(run);
-        String jobPath = jobUrl.substring(jobUrl.indexOf("job/") , jobUrl.length());
+        if(jobUrl == null || !jobUrl.contains(JOB_URL_SEARCH_PARM))return run.getParent().getDisplayName();
+
+        String jobPath = jobUrl.substring(jobUrl.indexOf(JOB_URL_SEARCH_PARM) , jobUrl.length());
         return jobPath;
     }
 

--- a/hygieia-jenkins-plugin/src/main/java/hygieia/utils/HygieiaUtils.java
+++ b/hygieia-jenkins-plugin/src/main/java/hygieia/utils/HygieiaUtils.java
@@ -144,7 +144,16 @@ public class HygieiaUtils {
         return run.getParent().getDisplayName();
     }
 
-
+    public static String getJobPath(AbstractBuild<?, ?> build){
+        String jobUrl = getJobUrl(build);
+        String jobPath = jobUrl.substring(jobUrl.indexOf("job/") , jobUrl.length());
+        return jobPath;
+    }
+    public static String getJobPath(Run<?, ?> run){
+        String jobUrl = getJobUrl(run);
+        String jobPath = jobUrl.substring(jobUrl.indexOf("job/") , jobUrl.length());
+        return jobPath;
+    }
 
     public static String getInstanceUrl(AbstractBuild<?, ?> build, TaskListener listener) {
         String envValue = getEnvironmentVariable(build, listener, "JENKINS_URL");

--- a/hygieia-jenkins-plugin/src/main/java/hygieia/utils/HygieiaUtils.java
+++ b/hygieia-jenkins-plugin/src/main/java/hygieia/utils/HygieiaUtils.java
@@ -133,7 +133,6 @@ public class HygieiaUtils {
     }
 
     public static String getJobUrl(Run<?, ?> run) {
-
         return run.getParent().getAbsoluteUrl();
     }
 


### PR DESCRIPTION
When using the Plugin for a multi branch pipeline, it was not easy to search for the jobs. Updating to store the path makes it easier to search for the jobs. @tabladrum @nireeshT 

Update:
If an issue is found with the job path then we return the job name. 