### PR TITLE
Bugfix: Github Collector Client chokes on URL-encoded `Link` header values.

### DIFF
--- a/collectors/scm/github/src/main/java/com/capitalone/dashboard/collector/DefaultGitHubClient.java
+++ b/collectors/scm/github/src/main/java/com/capitalone/dashboard/collector/DefaultGitHubClient.java
@@ -32,7 +32,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestOperations;
 
+import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -550,7 +552,14 @@ public class DefaultGitHubClient implements GitHubClient {
                                 nextPageUrl = parts[i].split(";")[0];
                                 nextPageUrl = nextPageUrl.replaceFirst("<","");
                                 nextPageUrl = nextPageUrl.replaceFirst(">","").trim();
-                                return nextPageUrl;
+                                // Github Link headers for 'next' and 'last' are URL Encoded
+                                String decodedPageUrl;
+                                try {
+                                    decodedPageUrl = URLDecoder.decode(nextPageUrl, StandardCharsets.UTF_8.name());
+                                } catch (UnsupportedEncodingException e) {
+                                    decodedPageUrl = URLDecoder.decode(nextPageUrl);
+                                }
+                                return decodedPageUrl;
                             }
                         }
                     }


### PR DESCRIPTION
Github's `Link` header values are URL Encoded. An example:

```
Key: Link
Value: <https://api.github.com/repositories/<some_repo>/commits?sha=refs%2Fheads%2Fmaster&since=2018-06-06T17%3A39Z&page=2>; rel="next", <https://api.github.com/repositories/<some_repo>/commits?sha=refs%2Fheads%2Fmaster&since=2018-06-06T17%3A39Z&page=2>; rel="last"
```

The client as written is incapable of correctly following an encoded link and results in a 404 Not Found error.

I suspect this error is what has been reported here and there already but hasn't been reproduced -- I spent the day spelunking this project's Issue history and noticed several issues similar to what I observed today.

I confirmed this resolution by crafting a small test I could step through in my IDE, that looked like:

```
    @Test
    public void breakingScenario() throws MalformedURLException, HygieiaException {

        GitHubRepo repo = new GitHubRepo();
        repo.setRepoUrl("https://github.com/<my organization>/<a high velocity repository>");
        repo.setBranch("refs/heads/master");
        repo.setPersonalAccessToken("<redacted>");

        GitHubSettings settings = new GitHubSettings();
        settings.setErrorThreshold(100);
        settings.setKey("<redacted>");
        GitHubClient client = new DefaultGitHubClient(settings, new RestOperationsSupplier());

        List<Commit> commits = client.getCommits(repo, true, new ArrayList<>());
        assert commits.size() > 0;
    }
```

On master, this test passes for repositories returning no `Link` header, but fails on repositories returning a `Link` header.

I was able to force the test to fail by amending my `GithubSettings` to search a larger trailing window, say 100 days instead of 14, as this ensured for any reasonably active repository that I'd see paged results.

After applying my decoding change, the test passed for all repositories I tried, and for all date ranges.