### PR TITLE
Skip build docker for rally

### DIFF
--- a/collectors/feature/rally/pom.xml
+++ b/collectors/feature/rally/pom.xml
@@ -56,7 +56,7 @@
         <groupId>com.spotify</groupId>
         <artifactId>docker-maven-plugin</artifactId>
         <configuration>
-          <skipDockerBuild>false</skipDockerBuild>
+          <skipDockerBuild>true</skipDockerBuild>
           <imageName>hygieia-rally-feature-collector</imageName>
           <dockerDirectory>${project.basedir}/docker</dockerDirectory>
           <resources>


### PR DESCRIPTION
When executing `mvn docker:build` on root directory, we will meet an error:

> [INFO] Scanning for projects...
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building com.capitalone.dashboard:rally-collector 2.0.5-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- docker-maven-plugin:0.4.10:build (default-cli) @ rally-collector ---
[INFO] Copying /opt/Hygieia/collectors/feature/rally/target/rally-collector-2.0.5-SNAPSHOT.jar -> /opt/Hygieia/collectors/feature/rally/target/docker/rally-collector-2.0.5-SNAPSHOT.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 5.416 s
[INFO] Finished at: 2018-06-21T12:53:04+08:00
[INFO] Final Memory: 25M/580M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.spotify:docker-maven-plugin:0.4.10:build (default-cli) on project rally-collector: Exception caught: basedir /opt/Hygieia/collectors/feature/rally/docker does not exist -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException

The reason is that rally has no docker file.
So, skip build docker for rally until there is docker file for rally.