### PR TITLE
Fix dashboard rename bug

### DIFF
--- a/api/src/main/java/com/capitalone/dashboard/rest/DashboardController.java
+++ b/api/src/main/java/com/capitalone/dashboard/rest/DashboardController.java
@@ -117,19 +117,11 @@ public class DashboardController {
             return ResponseEntity.ok("Unchanged");
         }
 
-        Iterable<Dashboard> allDashboard = dashboards();
-        boolean titleExist = false;
 
-        for(Dashboard l :allDashboard)
-        {
-            if (id.compareTo(l.getId()) == 0) {
-                //skip the current dashboard
-                continue;
-            }
-            if(l.getTitle().equals(request.getTitle()))
-            {
-                titleExist=true;
-            }
+        boolean titleExist = false;
+        List<Dashboard> existingDashboardList = dashboardService.getByTitle(newTitle);
+        if( existingDashboardList != null && existingDashboardList.size() > 0){
+            titleExist=true;
         }
 
         LOGGER.info("Existing Title:" + titleExist);

--- a/api/src/main/java/com/capitalone/dashboard/rest/DashboardController.java
+++ b/api/src/main/java/com/capitalone/dashboard/rest/DashboardController.java
@@ -120,7 +120,7 @@ public class DashboardController {
 
         boolean titleExist = false;
         List<Dashboard> existingDashboardList = dashboardService.getByTitle(newTitle);
-        if( existingDashboardList != null && existingDashboardList.size() > 0){
+        if( existingDashboardList != null && !existingDashboardList.isEmpty()){
             titleExist=true;
         }
 

--- a/api/src/main/java/com/capitalone/dashboard/service/DashboardService.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/DashboardService.java
@@ -173,6 +173,13 @@ public interface DashboardService {
     DataResponse<Iterable<Dashboard>> getByServiceAndApplication(String configItemService, String configItemApplication) throws HygieiaException;
 
     /**
+     *  Fetches a list of dashboards by title
+     * @param title
+     * @return
+     */
+    List<Dashboard> getByTitle(String title);
+
+    /**
      *  Updates Dashboard Business Items
      * @param dashboardId
      * @param dashboard

--- a/api/src/main/java/com/capitalone/dashboard/service/DashboardServiceImpl.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/DashboardServiceImpl.java
@@ -495,7 +495,12 @@ public class DashboardServiceImpl implements DashboardService {
         }
         return new DataResponse<>(rt, System.currentTimeMillis());
     }
+    @Override
+    public  List<Dashboard> getByTitle(String title) {
+        List<Dashboard> dashboard = dashboardRepository.findByTitle(title);
 
+        return dashboard;
+    }
 
     @Override
     public Dashboard updateDashboardWidgets(ObjectId dashboardId, Dashboard request) throws HygieiaException {
@@ -616,13 +621,17 @@ public class DashboardServiceImpl implements DashboardService {
         if(appName != null && !"".equals(appName)){
 
             Cmdb cmdb =  cmdbService.configurationItemByConfigurationItem(appName);
-            dashboard.setConfigurationItemBusServName(cmdb.getConfigurationItem());
-            dashboard.setValidServiceName(cmdb.isValidConfigItem());
+            if(cmdb !=null) {
+                dashboard.setConfigurationItemBusServName(cmdb.getConfigurationItem());
+                dashboard.setValidServiceName(cmdb.isValidConfigItem());
+            }
         }
         if(compName != null && !"".equals(compName)){
             Cmdb cmdb = cmdbService.configurationItemByConfigurationItem(compName);
-            dashboard.setConfigurationItemBusAppName(cmdb.getConfigurationItem());
-            dashboard.setValidAppName(cmdb.isValidConfigItem());
+            if(cmdb !=null) {
+                dashboard.setConfigurationItemBusAppName(cmdb.getConfigurationItem());
+                dashboard.setValidAppName(cmdb.isValidConfigItem());
+            }
         }
     }
 

--- a/api/src/test/java/com/capitalone/dashboard/rest/DashboardControllerTest.java
+++ b/api/src/test/java/com/capitalone/dashboard/rest/DashboardControllerTest.java
@@ -220,7 +220,7 @@ public class DashboardControllerTest {
         DashboardRequestTitle request = makeDashboardRequestTitle("new title");
 
         when(dashboardService.get(objectId)).thenReturn(orig);
-        when(dashboardService.all()).thenReturn(allDashboards);
+        when(dashboardService.getByTitle("new title")).thenReturn(allDashboards);
 
         mockMvc.perform(put("/dashboard/rename/" + objectId.toString())
                 .contentType(TestUtil.APPLICATION_JSON_UTF8)


### PR DESCRIPTION
The renameDashboard API pulls all existing dashboards and then searches each one for a dashboard with the same title. The causes performance issues when there are a high number of dashboards.

Changes include:
Removed search logic and added logic to directly check the db for dashboards with an existing title.
Also, added null check