### PR TITLE
Reverse Peer Review Logic - GHR takes precedence over LGTM

### DIFF
--- a/api-audit/src/test/java/com/capitalone/dashboard/common/CommonCodeReviewTest.java
+++ b/api-audit/src/test/java/com/capitalone/dashboard/common/CommonCodeReviewTest.java
@@ -48,7 +48,9 @@ public class CommonCodeReviewTest {
         apiSettings.setPeerReviewApprovalText("approved by");
         AuditReviewResponse<CodeReviewAuditStatus> codeReviewAuditRequestAuditReviewResponse = new AuditReviewResponse<>();
         Assert.assertEquals(false, CommonCodeReview.computePeerReviewStatus(makeGitRequest("All Users"), apiSettings, codeReviewAuditRequestAuditReviewResponse, Stream.of(makeCommit()).collect(Collectors.toList())));
-        Assert.assertEquals(false, codeReviewAuditRequestAuditReviewResponse.getAuditStatuses().toString().contains("PEER_REVIEW_BY_SERVICEACCOUNT"));
+        Assert.assertEquals(Boolean.TRUE,codeReviewAuditRequestAuditReviewResponse.getAuditStatuses().contains(CodeReviewAuditStatus.PEER_REVIEW_GHR));
+        Assert.assertEquals(Boolean.TRUE,codeReviewAuditRequestAuditReviewResponse.getAuditStatuses().contains(CodeReviewAuditStatus.PEER_REVIEW_BY_SERVICEACCOUNT));
+        Assert.assertEquals(Boolean.TRUE,codeReviewAuditRequestAuditReviewResponse.getAuditStatuses().contains(CodeReviewAuditStatus.PEER_REVIEW_GHR_SELF_APPROVAL));
     }
 
     private GitRequest makeGitRequest(String userAccount) {

--- a/api-audit/src/test/java/com/capitalone/dashboard/common/TestConstants.java
+++ b/api-audit/src/test/java/com/capitalone/dashboard/common/TestConstants.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public class TestConstants {
 
-    public static final List<String> SERVICE_ACCOUNTS = Arrays.asList("Service Accounts", "Unix");
+    public static final List<String> SERVICE_ACCOUNTS = Arrays.asList("Service Accounts", "UNIX");
 
     public static final List<String> USER_ACCOUNTS = Arrays.asList("User Accounts");
 }

--- a/api-audit/src/test/resources/collector_items/items.json
+++ b/api-audit/src/test/resources/collector_items/items.json
@@ -410,7 +410,6 @@
   },
   {
   "id" : "5ad5f605c23b391cfa1c01a4",
-  "_class" : "com.capitalone.dashboard.model.EratocodeComponent",
   "description" : "myapplication:mycomponent",
   "enabled" : false,
   "errors" : [],
@@ -418,13 +417,28 @@
   "collectorId" : "5af9ed53cba7165e8cc1069e",
   "lastUpdated" : 1524190250247,
   "options" : {
-    "applicationType" : null,
-    "componentName" : "mycomponent",
-    "applicationID" : [
+    "applicationType": null,
+    "componentName": "mycomponent",
+    "applicationID": [
       "SOMEAPPLICATION"
     ],
-    "applicationName" : "account-my-information",
-    "instanceUrl" : "https://scan.com"
+    "applicationName": "account-my-information",
+    "instanceUrl": "https://scan.com"
+    }
+  },
+  {
+    "id": "5b72e8cf964ed88375851445",
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": "56ca15297fab7c68bfdb420c",
+    "lastUpdated": 1534257790463,
+    "options": {
+      "password": "",
+      "personalAccessToken": "",
+      "branch": "master",
+      "userID": "",
+      "url": "https://mygithub.com/Devopscode/MultipleAuthorsGHRLGTM"
+    }
   }
-}
 ]

--- a/api-audit/src/test/resources/collectors/coll.json
+++ b/api-audit/src/test/resources/collectors/coll.json
@@ -53,7 +53,6 @@
   },
   {
     "id": "5af9ed53cba7165e8cc1069e",
-    "_class": "com.capitalone.dashboard.model.EratocodeOSSCollector",
     "eratocodeServers": [
       "https://scan.com"
     ],

--- a/api-audit/src/test/resources/commits/commits.json
+++ b/api-audit/src/test/resources/commits/commits.json
@@ -1658,5 +1658,45 @@
     "scmCommitTimestamp" : 1517025260000,
     "numberOfChanges" : 1,
     "type" : "New"
+  },
+  {
+    "id" : "5b72e8e4964ed8840546d27a",
+    "collectorItemId" : "5b72e8cf964ed88375851445",
+    "timestamp" : 1534257380557,
+    "firstEverCommit" : false,
+    "scmUrl" : "https://mygithub.com/Devopscode/MultipleAuthorsGHRLGTM",
+    "scmBranch" : "master",
+    "scmRevisionNumber" : "a0de0992e284f893da53b5e68bfbb2051a6159d1",
+    "scmCommitLog" : "Merge pull request #267 from Devopscode/dev\n\nJIRA DEV CC, JIRA QA CC, JIRA PT CC",
+    "scmAuthor" : "Author One",
+    "scmAuthorLogin" : "ghone",
+    "scmParentRevisionNumbers" : [
+      "c7e46107d9df0a652d4088c214b38dbec5f144ea",
+      "42d4dbb84bdbce8f7d105ef39a0b64a875707dd6"
+    ],
+    "scmCommitTimestamp" : 1533923201000,
+    "numberOfChanges" : 1,
+    "type" : "New",
+    "pullNumber" : "267"
+  },
+  {
+    "id" : "5b72e8e4964ed8840546d27d",
+    "collectorItemId" : "5b72e8cf964ed88375851445",
+    "timestamp" : 1534257380557,
+    "firstEverCommit" : false,
+    "scmUrl" : "https://mygithub.com/Devopscode/MultipleAuthorsGHRLGTM",
+    "scmBranch" : "master",
+    "scmRevisionNumber" : "c7e46107d9df0a652d4088c214b38dbec5f144ea",
+    "scmCommitLog" : "Merge pull request #266 from Devopscode/AMIUpdate\n\nAMI ID Update, DEV-QA-PT AMI Update",
+    "scmAuthor" : "Author One",
+    "scmAuthorLogin" : "ghone",
+    "scmParentRevisionNumbers" : [
+      "8e4f1cc4b5eb9d2b5a8ab79e14210a776d38eff3",
+      "e518f0444fcdb1ef26122e8da053e5b9655220a8"
+    ],
+    "scmCommitTimestamp" : 1533835517000,
+    "numberOfChanges" : 1,
+    "type" : "New",
+    "pullNumber" : "266"
   }
 ]

--- a/api-audit/src/test/resources/expected/4-github-review-merge.json
+++ b/api-audit/src/test/resources/expected/4-github-review-merge.json
@@ -2,9 +2,9 @@
     {
         "auditStatuses": [
             "PEER_REVIEW_GHR",
-            "GIT_BRANCH_STRATEGY",
+            "COMMITAUTHOR_EQ_MERGECOMMITER",
             "PULLREQ_REVIEWED_BY_PEER",
-            "COMMITAUTHOR_EQ_MERGECOMMITER"
+            "GIT_BRANCH_STRATEGY"
         ],
         "lastUpdated": 1516207278547,
         "pullRequest": {

--- a/api-audit/src/test/resources/expected/MultipleAuthorsGHR.json
+++ b/api-audit/src/test/resources/expected/MultipleAuthorsGHR.json
@@ -122,8 +122,8 @@
     },
     {
         "auditStatuses": [
-            "COMMITAUTHOR_NE_MERGECOMMITER",
             "PEER_REVIEW_GHR",
+            "COMMITAUTHOR_NE_MERGECOMMITER",
             "PULLREQ_NOT_PEER_REVIEWED",
             "PEER_REVIEW_GHR_SELF_APPROVAL",
             "GIT_BRANCH_STRATEGY"

--- a/api-audit/src/test/resources/expected/MultipleAuthorsGHRLGTM.json
+++ b/api-audit/src/test/resources/expected/MultipleAuthorsGHRLGTM.json
@@ -1,0 +1,292 @@
+[
+  {
+    "auditStatuses": [
+      "PULLREQ_REVIEWED_BY_PEER",
+      "COMMITAUTHOR_EQ_MERGECOMMITER",
+      "PEER_REVIEW_GHR",
+      "GIT_BRANCH_STRATEGY"
+    ],
+    "lastUpdated": 1534257790463,
+    "pullRequest": {
+      "scmUrl": "https://mygithub.com/Devopscode/MultipleAuthorsGHRLGTM",
+      "scmBranch": "master",
+      "scmRevisionNumber": "c7e46107d9df0a652d4088c214b38dbec5f144ea",
+      "scmMergeEventRevisionNumber": "c7e46107d9df0a652d4088c214b38dbec5f144ea",
+      "scmCommitLog": "AMI ID Update, DEV-QA-PT AMI Update",
+      "scmCommitTimestamp": 1533835519000,
+      "numberOfChanges": 3,
+      "id": "5b72e8e4964ed8840546d28b",
+      "orgName": "Devopscode",
+      "repoName": "MultipleAuthorsLGTMGHR",
+      "sourceRepo": "Devopscode/MultipleAuthorsLGTMGHR",
+      "sourceBranch": "AMIUpdate",
+      "targetRepo": "Devopscode/MultipleAuthorsLGTMGHR",
+      "targetBranch": "master",
+      "number": "266",
+      "collectorItemId": "5b72e8cf964ed88375851445",
+      "updatedAt": 1533835520000,
+      "createdAt": 1533834724000,
+      "closedAt": 0,
+      "state": "merged",
+      "mergedAt": 1533835519000,
+      "mergeAuthor": "ghone",
+      "timestamp": 1534257380522,
+      "resolutiontime": 795000,
+      "userId": "ghone",
+      "comments": [
+        {
+          "user": "ghtwo",
+          "userLDAPDN": "CN=ghtwo,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+          "createdAt": 1533835258000,
+          "updatedAt": 1533835258000,
+          "body": "Message from LGTM -- Someone besides the committers and the PR author should approve the pull request. If this is not possible, the PR author can approve to indicate they have reviewed the other commits in the PR. The PR author must approve with a comment directly on the PR (GitHub Reviews comments will not work).",
+          "status": ""
+        },
+        {
+          "user": "ghone",
+          "userLDAPDN": "CN=ghone,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+          "createdAt": 1533835397000,
+          "updatedAt": 1533835397000,
+          "body": "lgtm",
+          "status": ""
+        }
+      ],
+      "reviews": [
+        {
+          "body": "lgtm",
+          "state": "APPROVED",
+          "author": "ghtwo",
+          "authorLDAPDN": "CN=ghtwo,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+          "createdAt": 1533835257000,
+          "updatedAt": 1533835257000
+        }
+      ],
+      "commitStatuses": [
+        {
+          "state": "SUCCESS",
+          "context": "approvals/lgtmeow",
+          "description": "approved by ghtwo"
+        }
+      ],
+      "headSha": "e518f0444fcdb1ef26122e8da053e5b9655220a8",
+      "baseSha": "a0de0992e284f893da53b5e68bfbb2051a6159d1",
+      "requestType": "pull",
+      "commits": [
+        {
+          "scmRevisionNumber": "e713e56b319a3122bd4f65e85ac4697d137c3f74",
+          "scmCommitLog": "Updated link for cloud monitoring script",
+          "scmAuthor": "Author One",
+          "scmAuthorLogin": "ghone",
+          "scmAuthorLDAPDN": "CN=ghone,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+          "scmCommitTimestamp": 1533573113000,
+          "numberOfChanges": 0,
+          "timestamp": 0,
+          "firstEverCommit": false
+        },
+        {
+          "scmRevisionNumber": "4438259c60d5ee257bfb1008bc5c9b5b2204761b",
+          "scmCommitLog": "Merge pull request #262 from Devopscode/master\n\nAMI Update to Dev",
+          "scmAuthor": "Author One",
+          "scmAuthorLogin": "ghone",
+          "scmAuthorLDAPDN": "CN=ghone,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+          "scmCommitTimestamp": 1533580361000,
+          "numberOfChanges": 0,
+          "timestamp": 0,
+          "firstEverCommit": false
+        },
+        {
+          "scmRevisionNumber": "e518f0444fcdb1ef26122e8da053e5b9655220a8",
+          "scmCommitLog": "AMI ID update from application at Thu Aug 09 10:24:11 EDT 2018",
+          "scmAuthor": "author.two@mycorp.com",
+          "scmAuthorLogin": "ghtwo",
+          "scmAuthorLDAPDN": "CN=ghtwo,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+          "scmCommitTimestamp": 1533824651000,
+          "numberOfChanges": 0,
+          "timestamp": 0,
+          "firstEverCommit": false
+        }
+      ]
+    },
+    "commits": [
+      {
+        "scmRevisionNumber": "e713e56b319a3122bd4f65e85ac4697d137c3f74",
+        "scmCommitLog": "Updated link for cloud monitoring script",
+        "scmAuthor": "Author One",
+        "scmAuthorLogin": "ghone",
+        "scmAuthorLDAPDN": "CN=ghone,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+        "scmCommitTimestamp": 1533573113000,
+        "numberOfChanges": 0,
+        "timestamp": 0,
+        "firstEverCommit": false
+      },
+      {
+        "scmRevisionNumber": "4438259c60d5ee257bfb1008bc5c9b5b2204761b",
+        "scmCommitLog": "Merge pull request #262 from Devopscode/master\n\nAMI Update to Dev",
+        "scmAuthor": "Author One",
+        "scmAuthorLogin": "ghone",
+        "scmAuthorLDAPDN": "CN=ghone,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+        "scmCommitTimestamp": 1533580361000,
+        "numberOfChanges": 0,
+        "timestamp": 0,
+        "firstEverCommit": false
+      },
+      {
+        "scmRevisionNumber": "e518f0444fcdb1ef26122e8da053e5b9655220a8",
+        "scmCommitLog": "AMI ID update from application at Thu Aug 09 10:24:11 EDT 2018",
+        "scmAuthor": "author.two@mycorp.com",
+        "scmAuthorLogin": "ghtwo",
+        "scmAuthorLDAPDN": "CN=ghtwo,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+        "scmCommitTimestamp": 1533824651000,
+        "numberOfChanges": 0,
+        "timestamp": 0,
+        "firstEverCommit": false
+      }
+    ],
+    "scmUrl": "https://mygithub.com/Devopscode/MultipleAuthorsGHRLGTM",
+    "scmBranch": "master"
+  },
+  {
+    "auditStatuses": [
+      "PULLREQ_REVIEWED_BY_PEER",
+      "COMMITAUTHOR_EQ_MERGECOMMITER",
+      "PEER_REVIEW_GHR",
+      "GIT_BRANCH_STRATEGY"
+    ],
+    "lastUpdated": 1534257790463,
+    "pullRequest": {
+      "scmUrl": "https://mygithub.com/Devopscode/MultipleAuthorsGHRLGTM",
+      "scmBranch": "master",
+      "scmRevisionNumber": "a0de0992e284f893da53b5e68bfbb2051a6159d1",
+      "scmMergeEventRevisionNumber": "a0de0992e284f893da53b5e68bfbb2051a6159d1",
+      "scmCommitLog": "JIRA DEV CC, JIRA QA CC, JIRA PT CC",
+      "scmCommitTimestamp": 1533923204000,
+      "numberOfChanges": 3,
+      "id": "5b72e8e4964ed8840546d289",
+      "orgName": "Devopscode",
+      "repoName": "MultipleAuthorsLGTMGHR",
+      "sourceRepo": "Devopscode/MultipleAuthorsLGTMGHR",
+      "sourceBranch": "dev",
+      "targetRepo": "Devopscode/MultipleAuthorsLGTMGHR",
+      "targetBranch": "master",
+      "number": "267",
+      "collectorItemId": "5b72e8cf964ed88375851445",
+      "updatedAt": 1533923204000,
+      "createdAt": 1533922551000,
+      "closedAt": 0,
+      "state": "merged",
+      "mergedAt": 1533923204000,
+      "mergeAuthor": "ghone",
+      "timestamp": 1534257380426,
+      "resolutiontime": 653000,
+      "userId": "ghone",
+      "comments": [],
+      "reviews": [
+        {
+          "body": "lgtm",
+          "state": "APPROVED",
+          "author": "ghtwo",
+          "authorLDAPDN": "CN=ghtwo,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+          "createdAt": 1533923014000,
+          "updatedAt": 1533923014000
+        }
+      ],
+      "commitStatuses": [
+        {
+          "state": "SUCCESS",
+          "context": "testAMICFTUpdate",
+          "description": "Stage built successfully"
+        },
+        {
+          "state": "SUCCESS",
+          "context": "testCodeChange",
+          "description": "Stage built successfully"
+        },
+        {
+          "state": "SUCCESS",
+          "context": "continuous-integration/jenkins/branch",
+          "description": "This commit looks good"
+        },
+        {
+          "state": "SUCCESS",
+          "context": "approvals/lgtmeow",
+          "description": "approved by ghtwo"
+        }
+      ],
+      "headSha": "b643a5f7aa7aadc7858f6a5c2baf2073955226fb",
+      "baseSha": "a0de0992e284f893da53b5e68bfbb2051a6159d1",
+      "requestType": "pull",
+      "commits": [
+        {
+          "scmRevisionNumber": "ef9502674c89dc4f45bb1619f07eebeb4c3cc158",
+          "scmCommitLog": "Merge pull request #265 from Devopscode/AMIUpdate\n\nAMI ID Update for CFT Files by application",
+          "scmAuthor": "Author One",
+          "scmAuthorLogin": "ghone",
+          "scmAuthorLDAPDN": "CN=ghone,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+          "scmCommitTimestamp": 1533834582000,
+          "numberOfChanges": 0,
+          "timestamp": 0,
+          "firstEverCommit": false
+        },
+        {
+          "scmRevisionNumber": "d389d05920f4fbd0d609ba193889c44be9516fcc",
+          "scmCommitLog": "Merge branch 'master' into dev",
+          "scmAuthor": "Author One",
+          "scmAuthorLogin": "ghone",
+          "scmAuthorLDAPDN": "CN=ghone,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+          "scmCommitTimestamp": 1533844954000,
+          "numberOfChanges": 0,
+          "timestamp": 0,
+          "firstEverCommit": false
+        },
+        {
+          "scmRevisionNumber": "42d4dbb84bdbce8f7d105ef39a0b64a875707dd6",
+          "scmCommitLog": "JIRA TEST CC",
+          "scmAuthor": "Author One",
+          "scmAuthorLogin": "ghone",
+          "scmAuthorLDAPDN": "CN=ghone,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+          "scmCommitTimestamp": 1533909401000,
+          "numberOfChanges": 0,
+          "timestamp": 0,
+          "firstEverCommit": false
+        }
+      ]
+    },
+    "commits": [
+      {
+        "scmRevisionNumber": "ef9502674c89dc4f45bb1619f07eebeb4c3cc158",
+        "scmCommitLog": "Merge pull request #265 from Devopscode/AMIUpdate\n\nAMI ID Update for CFT Files by application",
+        "scmAuthor": "Author One",
+        "scmAuthorLogin": "ghone",
+        "scmAuthorLDAPDN": "CN=ghone,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+        "scmCommitTimestamp": 1533834582000,
+        "numberOfChanges": 0,
+        "timestamp": 0,
+        "firstEverCommit": false
+      },
+      {
+        "scmRevisionNumber": "d389d05920f4fbd0d609ba193889c44be9516fcc",
+        "scmCommitLog": "Merge branch 'master' into dev",
+        "scmAuthor": "Author One",
+        "scmAuthorLogin": "ghone",
+        "scmAuthorLDAPDN": "CN=ghone,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+        "scmCommitTimestamp": 1533844954000,
+        "numberOfChanges": 0,
+        "timestamp": 0,
+        "firstEverCommit": false
+      },
+      {
+        "scmRevisionNumber": "42d4dbb84bdbce8f7d105ef39a0b64a875707dd6",
+        "scmCommitLog": "JIRA TEST CC",
+        "scmAuthor": "Author One",
+        "scmAuthorLogin": "ghone",
+        "scmAuthorLDAPDN": "CN=ghone,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+        "scmCommitTimestamp": 1533909401000,
+        "numberOfChanges": 0,
+        "timestamp": 0,
+        "firstEverCommit": false
+      }
+    ],
+    "scmUrl": "https://mygithub.com/Devopscode/MultipleAuthorsGHRLGTM",
+    "scmBranch": "master"
+  }
+]

--- a/api-audit/src/test/resources/expected/MultipleAuthorsLGTM.json
+++ b/api-audit/src/test/resources/expected/MultipleAuthorsLGTM.json
@@ -1,11 +1,11 @@
 [
     {
         "auditStatuses": [
-            "PEER_REVIEW_LGTM_SELF_APPROVAL",
-            "GIT_BRANCH_STRATEGY",
-            "COMMITAUTHOR_NE_MERGECOMMITER",
             "PEER_REVIEW_LGTM_SUCCESS",
-            "PULLREQ_NOT_PEER_REVIEWED"
+            "COMMITAUTHOR_NE_MERGECOMMITER",
+            "PEER_REVIEW_LGTM_SELF_APPROVAL",
+            "PULLREQ_NOT_PEER_REVIEWED",
+            "GIT_BRANCH_STRATEGY"
         ],
         "lastUpdated": 1516735761179,
         "pullRequest": {

--- a/api-audit/src/test/resources/gitrequests/prs.json
+++ b/api-audit/src/test/resources/gitrequests/prs.json
@@ -1042,5 +1042,211 @@
         "numberOfChanges" : 0
       }
     ]
+  },
+  {
+  "id" : "5b72e8e4964ed8840546d28b",
+  "scmUrl" : "https://mygithub.com/Devopscode/MultipleAuthorsGHRLGTM",
+  "scmBranch" : "master",
+  "scmRevisionNumber" : "c7e46107d9df0a652d4088c214b38dbec5f144ea",
+  "scmMergeEventRevisionNumber" : "c7e46107d9df0a652d4088c214b38dbec5f144ea",
+  "scmCommitLog" : "AMI ID Update, DEV-QA-PT AMI Update",
+  "scmCommitTimestamp" : 1533835519000,
+  "numberOfChanges" : 3,
+  "orgName" : "Devopscode",
+  "repoName" : "MultipleAuthorsLGTMGHR",
+  "sourceRepo" : "Devopscode/MultipleAuthorsLGTMGHR",
+  "sourceBranch" : "AMIUpdate",
+  "targetRepo" : "Devopscode/MultipleAuthorsLGTMGHR",
+  "targetBranch" : "master",
+  "number" : "266",
+  "collectorItemId" : "5b72e8cf964ed88375851445",
+  "updatedAt" : 1533835520000,
+  "createdAt" : 1533834724000,
+  "closedAt" : 0,
+  "state" : "merged",
+  "mergedAt" : 1533835519000,
+  "mergeAuthor" : "ghone",
+  "mergeAuthorLDAPDN" : "CN=ghone,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+  "timestamp" : 1534257380522,
+  "resolutiontime" : 795000,
+  "userId" : "ghone",
+  "comments" : [
+    {
+      "user" : "ghtwo",
+      "userLDAPDN" : "CN=ghtwo,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+      "createdAt" : 1533835258000,
+      "updatedAt" : 1533835258000,
+      "body" : "Message from LGTM -- Someone besides the committers and the PR author should approve the pull request. If this is not possible, the PR author can approve to indicate they have reviewed the other commits in the PR. The PR author must approve with a comment directly on the PR (GitHub Reviews comments will not work).",
+      "status" : ""
+    },
+    {
+      "user" : "ghone",
+      "userLDAPDN" : "CN=ghone,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+      "createdAt" : 1533835397000,
+      "updatedAt" : 1533835397000,
+      "body" : "lgtm",
+      "status" : ""
+    }
+  ],
+  "reviews" : [
+    {
+      "body" : "lgtm",
+      "state" : "APPROVED",
+      "author" : "ghtwo",
+      "authorLDAPDN" : "CN=ghtwo,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+      "createdAt" : 1533835257000,
+      "updatedAt" : 1533835257000
+    }
+  ],
+  "commitStatuses" : [
+    {
+      "state" : "SUCCESS",
+      "context" : "approvals/lgtmeow",
+      "description" : "approved by ghtwo"
+    }
+  ],
+  "headSha" : "e518f0444fcdb1ef26122e8da053e5b9655220a8",
+  "baseSha" : "a0de0992e284f893da53b5e68bfbb2051a6159d1",
+  "requestType" : "pull",
+  "commits" : [
+    {
+      "id" : null,
+      "timestamp" : 0,
+      "firstEverCommit" : false,
+      "scmRevisionNumber" : "e713e56b319a3122bd4f65e85ac4697d137c3f74",
+      "scmCommitLog" : "Updated link for cloud monitoring script",
+      "scmAuthor" : "Author One",
+      "scmAuthorLogin" : "ghone",
+      "scmAuthorLDAPDN" : "CN=ghone,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+      "scmCommitTimestamp" : 1533573113000,
+      "numberOfChanges" : 0
+    },
+    {
+      "id" : null,
+      "timestamp" : 0,
+      "firstEverCommit" : false,
+      "scmRevisionNumber" : "4438259c60d5ee257bfb1008bc5c9b5b2204761b",
+      "scmCommitLog" : "Merge pull request #262 from Devopscode/master\n\nAMI Update to Dev",
+      "scmAuthor" : "Author One",
+      "scmAuthorLogin" : "ghone",
+      "scmAuthorLDAPDN" : "CN=ghone,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+      "scmCommitTimestamp" : 1533580361000,
+      "numberOfChanges" : 0
+    },
+    {
+      "id" : null,
+      "timestamp" : 0,
+      "firstEverCommit" : false,
+      "scmRevisionNumber" : "e518f0444fcdb1ef26122e8da053e5b9655220a8",
+      "scmCommitLog" : "AMI ID update from application at Thu Aug 09 10:24:11 EDT 2018",
+      "scmAuthor" : "author.two@mycorp.com",
+      "scmAuthorLogin" : "ghtwo",
+      "scmAuthorLDAPDN" : "CN=ghtwo,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+      "scmCommitTimestamp" : 1533824651000,
+      "numberOfChanges" : 0
+    }
+  ]
+  },
+  {
+    "id" : "5b72e8e4964ed8840546d289",
+    "scmUrl" : "https://mygithub.com/Devopscode/MultipleAuthorsGHRLGTM",
+    "scmBranch" : "master",
+    "scmRevisionNumber" : "a0de0992e284f893da53b5e68bfbb2051a6159d1",
+    "scmMergeEventRevisionNumber" : "a0de0992e284f893da53b5e68bfbb2051a6159d1",
+    "scmCommitLog" : "JIRA DEV CC, JIRA QA CC, JIRA PT CC",
+    "scmCommitTimestamp" : 1533923204000,
+    "numberOfChanges" : 3,
+    "orgName" : "Devopscode",
+    "repoName" : "MultipleAuthorsLGTMGHR",
+    "sourceRepo" : "Devopscode/MultipleAuthorsLGTMGHR",
+    "sourceBranch" : "dev",
+    "targetRepo" : "Devopscode/MultipleAuthorsLGTMGHR",
+    "targetBranch" : "master",
+    "number" : "267",
+    "collectorItemId" : "5b72e8cf964ed88375851445",
+    "updatedAt" : 1533923204000,
+    "createdAt" : 1533922551000,
+    "closedAt" : 0,
+    "state" : "merged",
+    "mergedAt" : 1533923204000,
+    "mergeAuthor" : "ghone",
+    "mergeAuthorLDAPDN" : "CN=ghone,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+    "timestamp" : 1534257380426,
+    "resolutiontime" : 653000,
+    "userId" : "ghone",
+    "comments" : [],
+    "reviews" : [
+      {
+        "body" : "lgtm",
+        "state" : "APPROVED",
+        "author" : "ghtwo",
+        "authorLDAPDN" : "CN=ghtwo,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+        "createdAt" : 1533923014000,
+        "updatedAt" : 1533923014000
+      }
+    ],
+    "commitStatuses" : [
+      {
+        "state" : "SUCCESS",
+        "context" : "testAMICFTUpdate",
+        "description" : "Stage built successfully"
+      },
+      {
+        "state" : "SUCCESS",
+        "context" : "testCodeChange",
+        "description" : "Stage built successfully"
+      },
+      {
+        "state" : "SUCCESS",
+        "context" : "continuous-integration/jenkins/branch",
+        "description" : "This commit looks good"
+      },
+      {
+        "state" : "SUCCESS",
+        "context" : "approvals/lgtmeow",
+        "description" : "approved by ghtwo"
+      }
+    ],
+    "headSha" : "b643a5f7aa7aadc7858f6a5c2baf2073955226fb",
+    "baseSha" : "a0de0992e284f893da53b5e68bfbb2051a6159d1",
+    "requestType" : "pull",
+    "commits" : [
+      {
+        "_id" : null,
+        "timestamp" : 0,
+        "firstEverCommit" : false,
+        "scmRevisionNumber" : "ef9502674c89dc4f45bb1619f07eebeb4c3cc158",
+        "scmCommitLog" : "Merge pull request #265 from Devopscode/AMIUpdate\n\nAMI ID Update for CFT Files by application",
+        "scmAuthor" : "Author One",
+        "scmAuthorLogin" : "ghone",
+        "scmAuthorLDAPDN" : "CN=ghone,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+        "scmCommitTimestamp" : 1533834582000,
+        "numberOfChanges" : 0
+      },
+      {
+        "_id" : null,
+        "timestamp" : 0,
+        "firstEverCommit" : false,
+        "scmRevisionNumber" : "d389d05920f4fbd0d609ba193889c44be9516fcc",
+        "scmCommitLog" : "Merge branch 'master' into dev",
+        "scmAuthor" : "Author One",
+        "scmAuthorLogin" : "ghone",
+        "scmAuthorLDAPDN" : "CN=ghone,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+        "scmCommitTimestamp" : 1533844954000,
+        "numberOfChanges" : 0
+      },
+      {
+        "_id" : null,
+        "timestamp" : 0,
+        "firstEverCommit" : false,
+        "scmRevisionNumber" : "42d4dbb84bdbce8f7d105ef39a0b64a875707dd6",
+        "scmCommitLog" : "JIRA TEST CC",
+        "scmAuthor" : "Author One",
+        "scmAuthorLogin" : "ghone",
+        "scmAuthorLDAPDN" : "CN=ghone,OU=Developers,OU=All Users,DC=myc,DC=ds,DC=mycorp,DC=com",
+        "scmCommitTimestamp" : 1533909401000,
+        "numberOfChanges" : 0
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Implemented reversal of Peer Review logic, If both Github review(GHR) and LGTM are present then Native Github Reviews take precedence.